### PR TITLE
Add Microsoft 365 OAuth settings and XOAUTH2 support

### DIFF
--- a/Core/Lib/Email/NewMail.php
+++ b/Core/Lib/Email/NewMail.php
@@ -28,11 +28,15 @@ use FacturaScripts\Dinamic\Lib\Email\TextBlock as DinTextBlock;
 use FacturaScripts\Dinamic\Model\EmailNotification;
 use FacturaScripts\Dinamic\Model\EmailSent;
 use FacturaScripts\Dinamic\Model\Empresa;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\OAuth;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
+use TheNetworg\OAuth2\Client\Provider\Azure;
+use Throwable;
 
 /**
  * Description of NewMail
@@ -43,6 +47,10 @@ use Twig\Error\SyntaxError;
 class NewMail
 {
     const ATTACHMENTS_TMP_PATH = 'MyFiles/Tmp/Email/';
+
+    protected const XOAUTH2_REQUIRED_SETTINGS = ['tenant_id', 'client_id', 'client_secret', 'redirect_uri', 'refresh_token'];
+
+    protected const XOAUTH2_SCOPE = 'https://outlook.office365.com/.default';
 
     /** @var Empresa */
     public $empresa;
@@ -67,6 +75,9 @@ class NewMail
 
     /** @var PHPMailer */
     protected $mail;
+
+    /** @var array|null */
+    protected $oauthSettings;
 
     /** @var array */
     private static $mailer = ['mail' => 'Mail', 'sendmail' => 'SendMail', 'smtp' => 'SMTP'];
@@ -106,9 +117,12 @@ class NewMail
         $this->mail->Mailer = Tools::settings('email', 'mailer');
 
         $this->mail->SMTPSecure = Tools::settings('email', 'enc', '');
-        if ($this->mail->SMTPSecure) {
+        $authType = Tools::settings('email', 'authtype', '');
+        if ($this->mail->SMTPSecure || 'XOAUTH2' === $authType) {
             $this->mail->SMTPAuth = true;
-            $this->mail->AuthType = Tools::settings('email', 'authtype', '');
+        }
+        if (!empty($authType)) {
+            $this->mail->AuthType = $authType;
         }
 
         $this->mail->Host = Tools::settings('email', 'host');
@@ -225,7 +239,50 @@ class NewMail
      */
     public function canSendMail(): bool
     {
-        return !empty($this->fromEmail) && !empty($this->mail->Password) && !empty($this->mail->Host);
+        if (empty($this->fromEmail) || empty($this->mail->Host)) {
+            return false;
+        }
+
+        if ($this->isXOAUTH2()) {
+            return $this->hasOAuthCredentials();
+        }
+
+        return !empty($this->mail->Password);
+    }
+
+    protected function getOAuthSettings(): array
+    {
+        if (null === $this->oauthSettings) {
+            $this->oauthSettings = [];
+            foreach (self::XOAUTH2_REQUIRED_SETTINGS as $key) {
+                $this->oauthSettings[$key] = trim((string)Tools::settings('email', $key, ''));
+            }
+        }
+
+        return $this->oauthSettings;
+    }
+
+    protected function hasOAuthCredentials(?array $settings = null): bool
+    {
+        $settings = $settings ?? $this->getOAuthSettings();
+        $missing = [];
+        foreach (self::XOAUTH2_REQUIRED_SETTINGS as $key) {
+            if (empty($settings[$key])) {
+                $missing[] = $key;
+            }
+        }
+
+        if (!empty($missing)) {
+            Tools::log()->error('XOAUTH2 configuration incomplete: missing ' . implode(', ', $missing) . '.');
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function isXOAUTH2(): bool
+    {
+        return 'XOAUTH2' === $this->mail->AuthType;
     }
 
     public function cc(string $email, string $name = ''): NewMail
@@ -331,6 +388,77 @@ class NewMail
         return $this;
     }
 
+    protected function applyOAuth(): bool
+    {
+        $settings = $this->getOAuthSettings();
+        if (false === $this->hasOAuthCredentials($settings)) {
+            return false;
+        }
+
+        try {
+            $provider = $this->createOAuthProvider($settings);
+        } catch (Throwable $exception) {
+            Tools::log()->error('Unable to initialize OAuth provider: ' . $exception->getMessage());
+            return false;
+        }
+
+        try {
+            $accessToken = $this->requestOAuthAccessToken($provider, $settings);
+        } catch (IdentityProviderException $exception) {
+            Tools::log()->error('OAuth token refresh failed: ' . $exception->getMessage());
+            return false;
+        } catch (Throwable $exception) {
+            Tools::log()->error('OAuth provider error: ' . $exception->getMessage());
+            return false;
+        }
+
+        $refreshToken = method_exists($accessToken, 'getRefreshToken') ? $accessToken->getRefreshToken() : null;
+        if (!empty($refreshToken) && $refreshToken !== $settings['refresh_token']) {
+            Tools::settingsSet('email', 'refresh_token', $refreshToken);
+            $this->oauthSettings['refresh_token'] = $refreshToken;
+            try {
+                if (false === Tools::settingsSave()) {
+                    Tools::log()->warning('Unable to persist refreshed OAuth token. The in-memory value will be used.');
+                }
+            } catch (Throwable $exception) {
+                Tools::log()->warning('Unable to persist refreshed OAuth token: ' . $exception->getMessage());
+            }
+        }
+
+        $this->mail->setOAuth(new OAuth([
+            'provider' => $provider,
+            'clientId' => $settings['client_id'],
+            'clientSecret' => $settings['client_secret'],
+            'refreshToken' => $this->oauthSettings['refresh_token'] ?? $settings['refresh_token'],
+            'scope' => self::XOAUTH2_SCOPE,
+            'userName' => $this->mail->Username,
+        ]));
+
+        return true;
+    }
+
+    protected function createOAuthProvider(array $settings)
+    {
+        if (false === class_exists(Azure::class)) {
+            throw new \RuntimeException('Azure OAuth provider dependency not installed. Run composer update to install thenetworg/oauth2-azure.');
+        }
+
+        return new Azure([
+            'clientId' => $settings['client_id'],
+            'clientSecret' => $settings['client_secret'],
+            'redirectUri' => $settings['redirect_uri'],
+            'tenant' => $settings['tenant_id'],
+        ]);
+    }
+
+    protected function requestOAuthAccessToken($provider, array $settings)
+    {
+        return $provider->getAccessToken('refresh_token', [
+            'refresh_token' => $settings['refresh_token'],
+            'scope' => self::XOAUTH2_SCOPE,
+        ]);
+    }
+
     /**
      * Envía el correo.
      *
@@ -343,6 +471,10 @@ class NewMail
     {
         if (false === $this->canSendMail()) {
             Tools::log()->warning('email-not-configured');
+            return false;
+        }
+
+        if ($this->isXOAUTH2() && false === $this->applyOAuth()) {
             return false;
         }
 

--- a/Core/XMLView/ConfigEmail.xml
+++ b/Core/XMLView/ConfigEmail.xml
@@ -67,6 +67,21 @@
             <column name="lowsecure" title="low-security" order="160">
                 <widget type="checkbox" fieldname="lowsecure"/>
             </column>
+            <column name="tenant-id" numcolumns="6" order="200">
+                <widget type="text" fieldname="tenant_id"/>
+            </column>
+            <column name="client-id" numcolumns="6" order="210">
+                <widget type="text" fieldname="client_id"/>
+            </column>
+            <column name="client-secret" numcolumns="6" order="220">
+                <widget type="password" fieldname="client_secret"/>
+            </column>
+            <column name="redirect-uri" numcolumns="6" order="230">
+                <widget type="text" fieldname="redirect_uri"/>
+            </column>
+            <column name="refresh-token" numcolumns="12" order="240">
+                <widget type="textarea" fieldname="refresh_token"/>
+            </column>
         </group>
         <group name="reply" title="reply" icon="fa-solid fa-reply" numcolumns="3">
             <column name="replytouseremail" title="email-replies" order="100">

--- a/Test/Core/Lib/Email/NewMailTest.php
+++ b/Test/Core/Lib/Email/NewMailTest.php
@@ -20,6 +20,8 @@
 namespace FacturaScripts\Test\Core\Lib\Email;
 
 use FacturaScripts\Core\Lib\Email\NewMail;
+use FacturaScripts\Core\Tools;
+use PHPMailer\PHPMailer\PHPMailer;
 use PHPUnit\Framework\TestCase;
 
 final class NewMailTest extends TestCase
@@ -66,5 +68,134 @@ final class NewMailTest extends TestCase
         $this->assertEmpty($mailer->getToAddresses());
         $this->assertEmpty($mailer->getCcAddresses());
         $this->assertCount(1, $mailer->getBccAddresses());
+    }
+
+    public function testCanSendMailWithXOAUTH2RequiresCredentials(): void
+    {
+        Tools::settingsClear();
+        Tools::settingsSet('email', 'email', 'user@example.com');
+        Tools::settingsSet('email', 'host', 'smtp.office365.com');
+        Tools::settingsSet('email', 'authtype', 'XOAUTH2');
+
+        $mailer = NewMail::create();
+
+        $this->assertFalse($mailer->canSendMail());
+    }
+
+    public function testCanSendMailWithXOAUTH2AndCredentials(): void
+    {
+        $this->configureXOAUTH2Settings();
+
+        $mailer = NewMail::create();
+
+        $this->assertTrue($mailer->canSendMail());
+    }
+
+    public function testSendWithXOAUTH2UsesOAuthProvider(): void
+    {
+        $this->configureXOAUTH2Settings();
+
+        $provider = new \stdClass();
+        $token = new DummyAccessToken('refresh-token');
+
+        $mailer = new NewMailOAuthTestDouble();
+        $mailer->provider = $provider;
+        $mailer->token = $token;
+
+        $mailStub = new TestMailerOAuthPHPMailer();
+        $mailStub->Mailer = 'SMTP';
+        $mailStub->Host = Tools::settings('email', 'host');
+        $mailStub->AuthType = 'XOAUTH2';
+        $mailStub->SMTPAuth = true;
+        $mailStub->Username = Tools::settings('email', 'user');
+
+        $property = new \ReflectionProperty(NewMail::class, 'mail');
+        $property->setAccessible(true);
+        $property->setValue($mailer, $mailStub);
+
+        $this->assertTrue($mailer->send());
+        $this->assertTrue($mailer->createOAuthProviderCalled);
+        $this->assertTrue($mailer->requestOAuthAccessTokenCalled);
+        $this->assertIsObject($mailStub->oauthConfig);
+    }
+
+    private function configureXOAUTH2Settings(): void
+    {
+        Tools::settingsClear();
+        Tools::settingsSet('email', 'email', 'user@example.com');
+        Tools::settingsSet('email', 'user', 'user@example.com');
+        Tools::settingsSet('email', 'host', 'smtp.office365.com');
+        Tools::settingsSet('email', 'mailer', 'SMTP');
+        Tools::settingsSet('email', 'port', '587');
+        Tools::settingsSet('email', 'enc', 'tls');
+        Tools::settingsSet('email', 'authtype', 'XOAUTH2');
+        Tools::settingsSet('email', 'tenant_id', 'tenant');
+        Tools::settingsSet('email', 'client_id', 'client');
+        Tools::settingsSet('email', 'client_secret', 'secret');
+        Tools::settingsSet('email', 'redirect_uri', 'https://example.com/callback');
+        Tools::settingsSet('email', 'refresh_token', 'refresh-token');
+        Tools::settingsSet('email', 'password', '');
+    }
+}
+
+class DummyAccessToken
+{
+    public function __construct(private readonly ?string $refreshToken)
+    {
+    }
+
+    public function getRefreshToken(): ?string
+    {
+        return $this->refreshToken;
+    }
+}
+
+class NewMailOAuthTestDouble extends NewMail
+{
+    public $provider;
+    public $token;
+    public $createOAuthProviderCalled = false;
+    public $requestOAuthAccessTokenCalled = false;
+
+    protected function renderHTML(): void
+    {
+        $this->html = '<p>mock</p>';
+    }
+
+    protected function createOAuthProvider(array $settings)
+    {
+        $this->createOAuthProviderCalled = true;
+        return $this->provider;
+    }
+
+    protected function requestOAuthAccessToken($provider, array $settings)
+    {
+        $this->requestOAuthAccessTokenCalled = true;
+        return $this->token;
+    }
+}
+
+class TestMailerOAuthPHPMailer extends PHPMailer
+{
+    public $oauthConfig;
+
+    public function __construct()
+    {
+        parent::__construct(true);
+    }
+
+    public function setOAuth($oauth)
+    {
+        $this->oauthConfig = $oauth;
+    }
+
+    public function smtpConnect($options = null, $timeout = 300)
+    {
+        return true;
+    }
+
+    public function send()
+    {
+        return true;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,14 @@
     "mk-j/php_xlsxwriter": "0.39",
     "parsecsv/php-parsecsv": "1.*",
     "phpmailer/phpmailer": "6.*",
+    "league/oauth2-client": "^2.6",
     "rospdf/pdf-php": "0.12.*",
     "twig/twig": "3.*",
     "tavo1987/ec-validador-cedula-ruc": "1.0.2",
     "globalcitizen/php-iban": "4.*",
     "pragmarx/google2fa": "^8.0",
-    "chillerlan/php-qrcode": "^4.0"
+    "chillerlan/php-qrcode": "^4.0",
+    "thenetworg/oauth2-azure": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "9.*",


### PR DESCRIPTION
## Summary
- add Microsoft 365 OAuth credential fields to the email configuration form
- require the league/oauth2-client and thenetworg/oauth2-azure packages for OAuth flows
- update NewMail to handle XOAUTH2 by validating settings, fetching access tokens and wiring PHPMailer OAuth with detailed logging
- extend the PHPUnit suite with XOAUTH2 coverage using mocked providers

## Testing
- php -l Core/Lib/Email/NewMail.php
- php -l Test/Core/Lib/Email/NewMailTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cad0e2d5088328b653e1ed7fdbe4f2