### PR TITLE
Add CopyVariantPrice plugin to copy variant price

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /doc/
 /MyFiles/
 /node_modules/
-/Plugins/
+/Plugins/*
+!/Plugins/CopyVariantPrice/
+!/Plugins/CopyVariantPrice/**
 /vendor/
 .DS_Store
 .htaccess

--- a/Plugins/CopyVariantPrice/Extension/Model/Variante.php
+++ b/Plugins/CopyVariantPrice/Extension/Model/Variante.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Extension for the Variante model to copy sale prices between variants.
+ */
+
+namespace FacturaScripts\Plugins\CopyVariantPrice\Extension\Model;
+
+use FacturaScripts\Core\Cache;
+
+class Variante
+{
+    public function clear(): \Closure
+    {
+        return function (): void {
+            $this->copyprice = false;
+        };
+    }
+
+    public function save(): \Closure
+    {
+        return function () {
+            if (empty($this->copyprice) || empty($this->idproducto)) {
+                return null;
+            }
+
+            $price = (float)$this->precio;
+            $margin = (float)$this->margen;
+
+            $where = ' WHERE idproducto = ' . self::$dataBase->var2str($this->idproducto);
+            if (!empty($this->idvariante)) {
+                $where .= ' AND idvariante <> ' . self::$dataBase->var2str($this->idvariante);
+            }
+
+            $sql = 'UPDATE ' . static::tableName()
+                . ' SET precio = ' . self::$dataBase->var2str($price)
+                . ', margen = ' . self::$dataBase->var2str($margin)
+                . $where . ';';
+
+            if (false !== self::$dataBase->exec($sql)) {
+                Cache::deleteMulti('model-' . $this->modelClassName() . '-');
+                Cache::deleteMulti('join-model-');
+                Cache::deleteMulti('table-' . static::tableName() . '-');
+            }
+
+            $this->copyprice = false;
+
+            return null;
+        };
+    }
+}

--- a/Plugins/CopyVariantPrice/Init.php
+++ b/Plugins/CopyVariantPrice/Init.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin CopyVariantPrice for FacturaScripts.
+ */
+
+namespace FacturaScripts\Plugins\CopyVariantPrice;
+
+use FacturaScripts\Core\Template\InitClass;
+
+class Init extends InitClass
+{
+    public function init(): void
+    {
+        $this->loadExtension(new Extension\Model\Variante());
+    }
+
+    public function uninstall(): void
+    {
+    }
+
+    public function update(): void
+    {
+    }
+}

--- a/Plugins/CopyVariantPrice/Translation/en_EN.json
+++ b/Plugins/CopyVariantPrice/Translation/en_EN.json
@@ -1,0 +1,4 @@
+{
+    "copy-variant-price": "Copy price to all variants",
+    "copy-variant-price-help": "Tick this box to apply the current price to every variant of this product."
+}

--- a/Plugins/CopyVariantPrice/Translation/es_ES.json
+++ b/Plugins/CopyVariantPrice/Translation/es_ES.json
@@ -1,0 +1,4 @@
+{
+    "copy-variant-price": "Copiar precio a todas las variantes",
+    "copy-variant-price-help": "Marca esta casilla para aplicar el precio actual al resto de variantes de este producto."
+}

--- a/Plugins/CopyVariantPrice/XMLView/EditVariante.xml
+++ b/Plugins/CopyVariantPrice/XMLView/EditVariante.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Custom view provided by the CopyVariantPrice plugin for FacturaScripts.
+ -->
+<view>
+    <columns>
+        <group name="data" numcolumns="12">
+            <column name="product" display="none" order="100">
+                <widget type="text" fieldname="idproducto" required="true"/>
+            </column>
+            <column name="reference" numcolumns="2" order="110">
+                <widget type="text" fieldname="referencia" maxlength="30" icon="fas fa-hashtag"/>
+            </column>
+            <column name="attribute-value-1" titleurl="ListAtributo" numcolumns="2" order="120">
+                <widget type="select" fieldname="idatributovalor1"/>
+            </column>
+            <column name="attribute-value-2" titleurl="ListAtributo" numcolumns="2" order="130">
+                <widget type="select" fieldname="idatributovalor2"/>
+            </column>
+            <column name="attribute-value-3" titleurl="ListAtributo" numcolumns="2" order="140">
+                <widget type="select" fieldname="idatributovalor3"/>
+            </column>
+            <column name="attribute-value-4" titleurl="ListAtributo" numcolumns="2" order="150">
+                <widget type="select" fieldname="idatributovalor4"/>
+            </column>
+            <column name="barcode" numcolumns="2" order="160">
+                <widget type="text" fieldname="codbarras" maxlength="20" icon="fas fa-barcode"/>
+            </column>
+            <column name="cost-price" display="right" numcolumns="2" order="170">
+                <widget type="money" decimal="2" fieldname="coste" class="calc-cost"/>
+            </column>
+            <column name="margin" display="right" numcolumns="2" order="180">
+                <widget type="percentage" fieldname="margen" class="calc-margin" min="0"/>
+            </column>
+            <column name="price" display="right" numcolumns="2" order="190">
+                <widget type="money" decimal="2" fieldname="precio" class="calc-price"/>
+            </column>
+            <column name="copy-price" numcolumns="2" order="195">
+                <widget type="checkbox" fieldname="copyprice" title="copy-variant-price" description="copy-variant-price-help"/>
+            </column>
+            <column name="stock" display="right" numcolumns="2" order="200">
+                <widget type="number" fieldname="stockfis" readonly="true"/>
+            </column>
+        </group>
+    </columns>
+</view>

--- a/Plugins/CopyVariantPrice/facturascripts.ini
+++ b/Plugins/CopyVariantPrice/facturascripts.ini
@@ -1,0 +1,4 @@
+name = 'CopyVariantPrice'
+description = 'Copiar el precio de venta de una variante al resto del producto.'
+version = 1.0
+min_version = 2024.0


### PR DESCRIPTION
# Descripción
- Crea el plugin CopyVariantPrice que añade una casilla en la vista de variantes para copiar el precio de venta al resto.
- Añade la extensión del modelo para propagar el precio y margen cuando se marca la casilla y limpia cachés.
- Incluye las traducciones y metadatos del plugin y ajusta el .gitignore para versionarlo.

## Description (english)
- Create the CopyVariantPrice plugin that adds a checkbox in the variants editor to copy the sale price to the remaining variants.
- Add the model extension that propagates price and margin when the checkbox is ticked and clears caches.
- Include plugin translations/metadata and tweak .gitignore to version the plugin.

## ¿Cómo has probado los cambios?
- [x] He revisado mi código antes de enviarlo.
- [ ] He probado que funciona correctamente en mi PC.
- [ ] He probado que funciona correctamente con una base de datos vacía.
- [ ] He ejecutado los tests unitarios.

### How has the changes been tested? (english)
- [x] I have reviewed my code before sending it.
- [ ] I have tested it on my PC.
- [ ] I have tested it on an empty database.
- [ ] I have run the unit tests.

------
https://chatgpt.com/codex/tasks/task_e_68cd122678588328bb23fb14ac0a7f11