### PR TITLE
Handle JSON-RPC notifications and session expiry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /doc/
 /MyFiles/
 /node_modules/
-/Plugins/
+/Plugins/*
+!/Plugins/McpApi/
+!/Plugins/McpApi/**
 /vendor/
 .DS_Store
 .htaccess

--- a/Core/Template/ApiController.php
+++ b/Core/Template/ApiController.php
@@ -94,6 +94,15 @@ abstract class ApiController implements ControllerInterface
         // comprobamos el token
         $altToken = $this->request->headers->get('Token', '');
         $token = $this->request->headers->get('X-Auth-Token', $altToken);
+        if (empty($token)) {
+            $authorization = $this->request->headers->get('Authorization', '');
+            if (!empty($authorization) && class_exists('FacturaScripts\\Plugins\\McpApi\\Lib\\OAuth\\TokenBroker')) {
+                $resolved = \FacturaScripts\Plugins\McpApi\Lib\OAuth\TokenBroker::resolveBearerToken($authorization);
+                if (!empty($resolved)) {
+                    $token = $resolved;
+                }
+            }
+        }
         if (false === $this->validateApiToken($token)) {
             $this->saveIncident();
             throw new KernelException('InvalidApiToken', Tools::lang()->trans('auth-token-invalid'));

--- a/Plugins/McpApi/Controller/McpOAuthAuthorize.php
+++ b/Plugins/McpApi/Controller/McpOAuthAuthorize.php
@@ -1,0 +1,164 @@
+<?php
+namespace FacturaScripts\Plugins\McpApi\Controller;
+
+use FacturaScripts\Core\Contract\ControllerInterface;
+use FacturaScripts\Core\Request;
+use FacturaScripts\Core\Response;
+use FacturaScripts\Plugins\McpApi\Lib\OAuth\TokenBroker;
+
+class McpOAuthAuthorize implements ControllerInterface
+{
+    private Request $request;
+    private Response $response;
+
+    public function __construct(string $className, string $url = '')
+    {
+        $this->request = Request::createFromGlobals();
+        $this->response = new Response();
+    }
+
+    public function getPageData(): array
+    {
+        return [];
+    }
+
+    public function run(): void
+    {
+        if ($this->request->isMethod(Request::METHOD_GET)) {
+            $this->handleGet();
+            return;
+        }
+
+        if ($this->request->isMethod(Request::METHOD_POST)) {
+            $this->handlePost();
+            return;
+        }
+
+        $this->response->setHttpCode(Response::HTTP_METHOD_NOT_ALLOWED);
+        $this->response->setContent('Method not allowed');
+        $this->response->send();
+    }
+
+    private function handleGet(string $error = ''): void
+    {
+        $clientId = $this->request->query('client_id', '');
+        $redirectUri = $this->request->query('redirect_uri', '');
+        $responseType = $this->request->query('response_type', 'code');
+        $state = $this->request->query('state', '');
+        $scope = $this->request->query('scope', '');
+        $codeChallenge = $this->request->query('code_challenge', '');
+        $codeMethod = $this->request->query('code_challenge_method', '');
+
+        if ($clientId === '' || $redirectUri === '' || $responseType !== 'code') {
+            $this->response->setHttpCode(Response::HTTP_BAD_REQUEST);
+            $this->response->setContent('Missing or invalid OAuth parameters.');
+            $this->response->send();
+            return;
+        }
+
+        $this->renderForm([
+            'client_id' => $clientId,
+            'redirect_uri' => $redirectUri,
+            'state' => $state,
+            'scope' => $scope,
+            'code_challenge' => $codeChallenge,
+            'code_challenge_method' => $codeMethod,
+        ], $error);
+    }
+
+    private function handlePost(): void
+    {
+        $clientId = $this->request->request->get('client_id', '');
+        $redirectUri = $this->request->request->get('redirect_uri', '');
+        $state = $this->request->request->get('state', '');
+        $scope = $this->request->request->get('scope', '');
+        $codeChallenge = $this->request->request->get('code_challenge', '');
+        $codeMethod = $this->request->request->get('code_challenge_method', '');
+        $apiKey = $this->request->request->get('api_key', '');
+
+        if ($clientId === '' || $redirectUri === '') {
+            $this->response->setHttpCode(Response::HTTP_BAD_REQUEST);
+            $this->response->setContent('Missing OAuth parameters.');
+            $this->response->send();
+            return;
+        }
+
+        $identity = TokenBroker::validateApiKey($apiKey);
+        if (null === $identity) {
+            $this->handleGet('La clave API no es válida o está desactivada.');
+            return;
+        }
+
+        if (!filter_var($redirectUri, FILTER_VALIDATE_URL)) {
+            $this->response->setHttpCode(Response::HTTP_BAD_REQUEST);
+            $this->response->setContent('redirect_uri must be an absolute URL.');
+            $this->response->send();
+            return;
+        }
+
+        $scopes = array_values(array_filter(preg_split('/\s+/', (string)$scope)));
+        $code = TokenBroker::issueAuthorizationCode($clientId, $identity, $redirectUri, $codeChallenge, $codeMethod, $scopes);
+
+        $params = ['code' => $code];
+        if ($state !== '') {
+            $params['state'] = $state;
+        }
+        if (!empty($scopes)) {
+            $params['scope'] = implode(' ', $scopes);
+        }
+
+        $separator = str_contains($redirectUri, '?') ? '&' : '?';
+        $location = $redirectUri . $separator . http_build_query($params);
+
+        $this->response->setHttpCode(302);
+        $this->response->headers->set('Location', $location);
+        $this->response->send();
+    }
+
+    private function renderForm(array $data, string $error): void
+    {
+        $scopeHint = $data['scope'] === '' ? 'Todas las operaciones permitidas por tu clave API.' : htmlspecialchars($data['scope'], ENT_QUOTES, 'UTF-8');
+        $errorHtml = $error === '' ? '' : '<p class="error">' . htmlspecialchars($error, ENT_QUOTES, 'UTF-8') . '</p>';
+
+        $html = '<!DOCTYPE html>'
+            . '<html lang="es">'
+            . '<head>'
+            . '<meta charset="utf-8">'
+            . '<title>Autorizar acceso MCP</title>'
+            . '<style>'
+            . 'body{font-family:system-ui, sans-serif;max-width:640px;margin:40px auto;padding:0 16px;color:#1f2933;}'
+            . 'h1{font-size:1.8rem;margin-bottom:0.5rem;}'
+            . 'p{line-height:1.5rem;}'
+            . 'form{margin-top:1.5rem;padding:1.5rem;border:1px solid #d9e2ec;border-radius:8px;}'
+            . 'label{display:block;font-weight:600;margin-bottom:0.5rem;}'
+            . 'input[type="text"],input[type="password"]{width:100%;padding:0.6rem;border:1px solid #bcccdc;border-radius:6px;}'
+            . '.error{color:#b91c1c;background:#fee2e2;padding:0.75rem;border-radius:6px;}'
+            . 'button{margin-top:1rem;background:#2563eb;color:#fff;padding:0.75rem 1.5rem;border:none;border-radius:6px;font-size:1rem;cursor:pointer;}'
+            . 'button:hover{background:#1d4ed8;}'
+            . '</style>'
+            . '</head>'
+            . '<body>'
+            . '<h1>Conectar FacturaScripts con un agente MCP</h1>'
+            . '<p>Introduce la clave API que quieras delegar. Se generará un token temporal compatible con OAuth 2.0 para que el agente pueda llamar a la API `/api/v3/mcp`.</p>'
+            . '<p><strong>Cliente:</strong> ' . htmlspecialchars($data['client_id'], ENT_QUOTES, 'UTF-8') . '</p>'
+            . '<p><strong>Ámbito solicitado:</strong> ' . $scopeHint . '</p>'
+            . $errorHtml
+            . '<form method="post">'
+            . '<input type="hidden" name="client_id" value="' . htmlspecialchars($data['client_id'], ENT_QUOTES, 'UTF-8') . '">'
+            . '<input type="hidden" name="redirect_uri" value="' . htmlspecialchars($data['redirect_uri'], ENT_QUOTES, 'UTF-8') . '">'
+            . '<input type="hidden" name="state" value="' . htmlspecialchars($data['state'], ENT_QUOTES, 'UTF-8') . '">'
+            . '<input type="hidden" name="scope" value="' . htmlspecialchars($data['scope'], ENT_QUOTES, 'UTF-8') . '">'
+            . '<input type="hidden" name="code_challenge" value="' . htmlspecialchars($data['code_challenge'], ENT_QUOTES, 'UTF-8') . '">'
+            . '<input type="hidden" name="code_challenge_method" value="' . htmlspecialchars($data['code_challenge_method'], ENT_QUOTES, 'UTF-8') . '">'
+            . '<label for="api_key">Clave API de FacturaScripts</label>'
+            . '<input type="password" id="api_key" name="api_key" required placeholder="Introduce tu clave API">'
+            . '<button type="submit">Autorizar</button>'
+            . '</form>'
+            . '<p style="margin-top:1.5rem;font-size:0.9rem;color:#52606d;">Puedes crear nuevas claves API desde Administrador → Usuarios → API.</p>'
+            . '</body>'
+            . '</html>';
+
+        $this->response->setContent($html);
+        $this->response->send();
+    }
+}

--- a/Plugins/McpApi/Controller/McpOAuthToken.php
+++ b/Plugins/McpApi/Controller/McpOAuthToken.php
@@ -1,0 +1,69 @@
+<?php
+namespace FacturaScripts\Plugins\McpApi\Controller;
+
+use FacturaScripts\Core\Contract\ControllerInterface;
+use FacturaScripts\Core\Request;
+use FacturaScripts\Core\Response;
+use FacturaScripts\Plugins\McpApi\Lib\OAuth\TokenBroker;
+
+class McpOAuthToken implements ControllerInterface
+{
+    private Request $request;
+    private Response $response;
+
+    public function __construct(string $className, string $url = '')
+    {
+        $this->request = Request::createFromGlobals();
+        $this->response = new Response();
+    }
+
+    public function getPageData(): array
+    {
+        return [];
+    }
+
+    public function run(): void
+    {
+        if (!$this->request->isMethod(Request::METHOD_POST)) {
+            $this->response->setHttpCode(Response::HTTP_METHOD_NOT_ALLOWED);
+            $this->response->setContent('Method not allowed');
+            $this->response->send();
+            return;
+        }
+
+        $grantType = $this->request->request->get('grant_type', '');
+        if ($grantType !== 'authorization_code') {
+            $this->respondError('unsupported_grant_type', 'Only the authorization_code grant is available.');
+            return;
+        }
+
+        $code = $this->request->request->get('code', '');
+        $clientId = $this->request->request->get('client_id', '');
+        $redirectUri = $this->request->request->get('redirect_uri', '');
+        $codeVerifier = $this->request->request->get('code_verifier');
+
+        if ($code === '' || $clientId === '' || $redirectUri === '') {
+            $this->respondError('invalid_request', 'code, client_id and redirect_uri are required.');
+            return;
+        }
+
+        $token = TokenBroker::exchangeCode($code, $clientId, $redirectUri, $codeVerifier === '' ? null : $codeVerifier);
+        if (null === $token) {
+            $this->respondError('invalid_grant', 'The authorization code is invalid or has expired.');
+            return;
+        }
+
+        $this->response->headers->set('Cache-Control', 'no-store');
+        $this->response->headers->set('Pragma', 'no-cache');
+        $this->response->json($token);
+    }
+
+    private function respondError(string $error, string $description): void
+    {
+        $this->response->setHttpCode(Response::HTTP_BAD_REQUEST);
+        $this->response->json([
+            'error' => $error,
+            'error_description' => $description,
+        ]);
+    }
+}

--- a/Plugins/McpApi/Controller/McpWellKnown.php
+++ b/Plugins/McpApi/Controller/McpWellKnown.php
@@ -1,0 +1,90 @@
+<?php
+namespace FacturaScripts\Plugins\McpApi\Controller;
+
+use FacturaScripts\Core\Contract\ControllerInterface;
+use FacturaScripts\Core\Request;
+use FacturaScripts\Core\Response;
+use FacturaScripts\Dinamic\Lib\API\Mcp;
+
+class McpWellKnown implements ControllerInterface
+{
+    private Request $request;
+    private Response $response;
+
+    public function __construct(string $className, string $url = '')
+    {
+        $this->request = Request::createFromGlobals();
+        $this->response = new Response();
+    }
+
+    public function getPageData(): array
+    {
+        return [];
+    }
+
+    public function run(): void
+    {
+        $host = $this->request->host();
+        $scheme = $this->detectScheme();
+        $baseUrl = $host === '' ? '' : $scheme . '://' . $host;
+
+        $manifest = [
+            'name' => 'facturascripts-mcp',
+            'version' => '2.0',
+            'description' => 'Model Context Protocol bridge that documents and proxies the FacturaScripts REST API.',
+            'protocol' => [
+                'spec_version' => Mcp::SPEC_VERSION,
+                'transport' => 'jsonrpc-2.0',
+            ],
+            'endpoints' => [
+                'rpc' => $baseUrl . '/api/v3/mcp',
+                'resources' => $baseUrl . '/api/v3/mcp/resources',
+                'custom_resources' => $baseUrl . '/api/v3/mcp/custom',
+                'oauth_authorize' => $baseUrl . '/mcp/oauth/authorize',
+                'oauth_token' => $baseUrl . '/mcp/oauth/token',
+            ],
+            'authentication' => [
+                'type' => 'oauth2',
+                'authorization_header' => 'Authorization: Bearer <token>',
+                'notes' => 'Complete the OAuth 2.0 authorization code flow to wrap a FacturaScripts API key into a one-hour Bearer token.',
+            ],
+            'capabilities' => [
+                'session_ttl_seconds' => Mcp::SESSION_TTL,
+                'rpc_methods' => [
+                    'session/create',
+                    'session/refresh',
+                    'session/close',
+                    'resources/list',
+                    'resources/get',
+                    'resources/schema',
+                    'resources/query',
+                    'resources/custom',
+                    'tools/list',
+                    'tools/call',
+                ],
+                'tools' => [
+                    'model_query',
+                    'model_mutation',
+                ],
+            ],
+        ];
+
+        $this->response->json($manifest);
+    }
+
+    private function detectScheme(): string
+    {
+        $forwarded = $this->request->header('X-Forwarded-Proto');
+        if (is_string($forwarded) && $forwarded !== '') {
+            $parts = explode(',', $forwarded);
+            return strtolower(trim($parts[0]));
+        }
+
+        $https = $this->request->header('HTTPS');
+        if (is_string($https) && $https !== '' && strtolower($https) !== 'off') {
+            return 'https';
+        }
+
+        return 'http';
+    }
+}

--- a/Plugins/McpApi/Init.php
+++ b/Plugins/McpApi/Init.php
@@ -1,0 +1,24 @@
+<?php
+namespace FacturaScripts\Plugins\McpApi;
+
+use FacturaScripts\Core\Kernel;
+
+class Init
+{
+    public function init(): void
+    {
+        Kernel::addRoute('/.well-known/mcp.json', '\\FacturaScripts\\Dinamic\\Controller\\McpWellKnown', 0, 'mcp-well-known');
+        Kernel::addRoute('/mcp/oauth/authorize', '\\FacturaScripts\\Dinamic\\Controller\\McpOAuthAuthorize', 0, 'mcp-oauth-authorize');
+        Kernel::addRoute('/mcp/oauth/token', '\\FacturaScripts\\Dinamic\\Controller\\McpOAuthToken', 0, 'mcp-oauth-token');
+    }
+
+    public function update(): void
+    {
+        // nothing to update programmatically
+    }
+
+    public function uninstall(): void
+    {
+        // nothing to clean up
+    }
+}

--- a/Plugins/McpApi/Lib/API/Mcp.php
+++ b/Plugins/McpApi/Lib/API/Mcp.php
@@ -1,0 +1,1405 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Dinamic\Lib\API;
+
+use Exception;
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Base\MiniLog;
+use FacturaScripts\Core\Cache;
+use FacturaScripts\Core\Controller\ApiRoot;
+use FacturaScripts\Core\Lib\API\APIModel;
+use FacturaScripts\Core\Lib\API\Base\APIResourceClass;
+use FacturaScripts\Core\Response;
+use FacturaScripts\Core\Template\ApiController;
+use FacturaScripts\Core\Template\ModelClass;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Plugins\McpApi\Lib\Mcp\RpcException;
+
+/**
+ * MCP discovery endpoint for the FacturaScripts REST API.
+ */
+class Mcp extends APIResourceClass
+{
+    private const RESOURCE_NAME = 'mcp';
+    private const SPEC_VERSION = '1.0.0';
+    private const JSON_RPC_VERSION = '2.0';
+    private const SESSION_TTL = 3600;
+    private const MAX_QUERY_LIMIT = 200;
+    private const ERROR_PARSE_ERROR = -32700;
+    private const ERROR_INVALID_REQUEST = -32600;
+    private const ERROR_METHOD_NOT_FOUND = -32601;
+    private const ERROR_INVALID_PARAMS = -32602;
+    private const ERROR_INTERNAL_ERROR = -32603;
+    private const ERROR_RESOURCE_NOT_FOUND = -32004;
+    private const ERROR_OPERATION_FAILED = -32010;
+    private const HTTP_NO_CONTENT = 204;
+
+    /** @var array|null */
+    private $cachedResources;
+
+    public function getResources(): array
+    {
+        return [self::RESOURCE_NAME => $this->setResource('Mcp')];
+    }
+
+    public function doGET(): bool
+    {
+        if (empty($this->params)) {
+            $this->returnResult($this->buildIndexDocument());
+            return true;
+        }
+
+        $section = array_shift($this->params);
+        switch ($section) {
+            case 'resources':
+                return $this->respondWithResources();
+
+            case 'custom':
+                $this->returnResult(['resources' => $this->buildCustomResources()]);
+                return true;
+
+            default:
+                $this->setError(Tools::trans('record-not-found'), null, Response::HTTP_NOT_FOUND);
+                return false;
+        }
+    }
+
+    public function doPOST(): bool
+    {
+        $rawInput = trim($this->request->rawInput());
+        if ($rawInput === '') {
+            $response = $this->buildRpcError(null, self::ERROR_PARSE_ERROR, 'Empty request body.');
+            $this->response->json($response);
+            return true;
+        }
+
+        $payload = json_decode($rawInput, true);
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            $response = $this->buildRpcError(null, self::ERROR_PARSE_ERROR, 'Invalid JSON payload: ' . json_last_error_msg());
+            $this->response->json($response);
+            return true;
+        }
+
+        if (!is_array($payload)) {
+            $response = $this->buildRpcError(null, self::ERROR_INVALID_REQUEST, 'Request payload must be a JSON object or array.');
+            $this->response->json($response);
+            return true;
+        }
+
+        $result = $this->handleJsonRpcPayload($payload);
+        if (null === $result) {
+            $this->response
+                ->setHttpCode(self::HTTP_NO_CONTENT)
+                ->setContent('');
+            $this->response->send();
+            return true;
+        }
+
+        $this->response->json($result);
+        return true;
+    }
+
+    private function buildCustomResources(): array
+    {
+        $resources = [];
+        foreach (ApiRoot::getCustomResources() as $resourceName) {
+            if ($resourceName === self::RESOURCE_NAME) {
+                continue;
+            }
+
+            $resources[] = [
+                'name' => $resourceName,
+                'endpoint' => $this->getAbsoluteUrl($this->buildEndpoint($resourceName)),
+                'notes' => 'Recurso especial gestionado por un controlador Api*. Revisa el código del controlador correspondiente para conocer parámetros y comportamiento.',
+            ];
+        }
+
+        return $resources;
+    }
+
+    private function buildIndexDocument(): array
+    {
+        $basePath = $this->getBasePath();
+        $resources = $this->getDiscoverableResources();
+
+        return [
+            'name' => 'facturascripts-mcp',
+            'description' => 'Punto de descubrimiento MCP que describe la API REST de FacturaScripts para agentes de IA.',
+            'spec_version' => self::SPEC_VERSION,
+            'api_version' => ApiController::API_VERSION,
+            'base_path' => $basePath,
+            'base_url' => $this->getAbsoluteUrl($basePath),
+            'resource_count' => count($resources),
+            'rpc_endpoint' => [
+                'url' => $this->getAbsoluteUrl($basePath . '/' . self::RESOURCE_NAME),
+                'transport' => 'jsonrpc-2.0',
+                'notes' => 'Envía peticiones JSON-RPC 2.0 para acceder a métodos como session/create, resources/query o tools/call.',
+            ],
+            'links' => [
+                [
+                    'rel' => 'resources',
+                    'href' => $this->getAbsoluteUrl($basePath . '/' . self::RESOURCE_NAME . '/resources'),
+                    'description' => 'Listado de recursos de modelo y sus operaciones.',
+                ],
+                [
+                    'rel' => 'custom-resources',
+                    'href' => $this->getAbsoluteUrl($basePath . '/' . self::RESOURCE_NAME . '/custom'),
+                    'description' => 'Recursos API adicionales gestionados por controladores específicos.',
+                ],
+            ],
+            'authentication' => [
+                'type' => 'api-key',
+                'header' => 'X-Auth-Token',
+                'alternate_header' => 'Token',
+                'notes' => 'Genera una clave en Administrador > Usuarios > API y envíala en la cabecera X-Auth-Token. También se acepta el encabezado Token.',
+            ],
+            'usage' => [
+                'filtering' => 'Utiliza filter[campo]=valor para filtrar resultados. Añade sufijos _like, _gt, _gte, _lt, _lte, _neq, _null o _notnull para operadores avanzados.',
+                'sorting' => 'Ordena con sort[campo]=ASC o DESC.',
+                'pagination' => 'Controla la paginación con limit (por defecto 50) y offset.',
+                'operation' => 'Combina filtros con operation[campo]=OR cuando necesites condiciones OR. Por defecto se utiliza AND.',
+                'rpc_methods' => [
+                    'session/create',
+                    'session/refresh',
+                    'resources/list',
+                    'resources/get',
+                    'resources/query',
+                    'tools/list',
+                    'tools/call'
+                ],
+            ],
+        ];
+    }
+
+    private function buildEndpoint(string $resourceName): string
+    {
+        return $this->getBasePath() . '/' . $resourceName;
+    }
+
+    private function buildModelOperations(string $resourceName, string $modelName): array
+    {
+        $primaryKey = $this->resolvePrimaryKey($modelName) ?? 'id';
+        $endpoint = $this->getAbsoluteUrl($this->buildEndpoint($resourceName));
+        $rpcEndpoint = $this->getAbsoluteUrl($this->buildEndpoint(self::RESOURCE_NAME));
+
+        return [
+            [
+                'name' => 'list',
+                'method' => 'GET',
+                'path' => $endpoint,
+                'description' => 'Lista registros del recurso.',
+                'query' => $this->getQueryDocumentation(),
+            ],
+            [
+                'name' => 'retrieve',
+                'method' => 'GET',
+                'path' => $endpoint . '/{' . $primaryKey . '}',
+                'description' => 'Obtiene un registro concreto por su identificador.',
+            ],
+            [
+                'name' => 'schema',
+                'method' => 'GET',
+                'path' => $endpoint . '/schema',
+                'description' => 'Devuelve la definición de campos del recurso.',
+            ],
+            [
+                'name' => 'create',
+                'method' => 'POST',
+                'path' => $endpoint,
+                'description' => 'Crea un nuevo registro. Envía los campos del modelo como JSON o formulario.',
+            ],
+            [
+                'name' => 'update',
+                'method' => 'PUT',
+                'path' => $endpoint . '/{' . $primaryKey . '}',
+                'description' => 'Actualiza un registro existente. Incluye el identificador en la ruta o en el cuerpo.',
+            ],
+            [
+                'name' => 'delete',
+                'method' => 'DELETE',
+                'path' => $endpoint . '/{' . $primaryKey . '}',
+                'description' => 'Elimina un registro existente.',
+            ],
+            [
+                'name' => 'rpc-query',
+                'method' => 'RPC',
+                'path' => $rpcEndpoint,
+                'description' => 'Invoca JSON-RPC resources/query con {"resource": "' . $resourceName . '"}.',
+            ],
+        ];
+    }
+
+    private function buildModelSchema(string $modelName): array
+    {
+        $class = '\\FacturaScripts\\Dinamic\\Model\\' . $modelName;
+        if (!class_exists($class)) {
+            return [];
+        }
+
+        try {
+            $model = new $class();
+        } catch (Exception $exception) {
+            Tools::log()->warning('Unable to instantiate model for MCP schema: ' . $modelName . ' -> ' . $exception->getMessage());
+            return [];
+        }
+
+        $schema = [];
+        foreach ($model->getModelFields() as $fieldName => $definition) {
+            $schema[$fieldName] = [
+                'type' => $definition['type'],
+                'length' => $definition['length'] ?? null,
+                'nullable' => (bool)($definition['is_nullable'] ?? false),
+                'default' => $definition['default'],
+            ];
+        }
+
+        return $schema;
+    }
+
+    private function buildResourceDefinition(string $resourceName, array $info, bool $includeSchemaFields = true): ?array
+    {
+        $type = $this->resolveResourceType($info['API']);
+        $endpoint = $this->getAbsoluteUrl($this->buildEndpoint($resourceName));
+
+        $definition = [
+            'name' => $resourceName,
+            'type' => $type,
+            'endpoint' => $endpoint,
+            'provider' => $info['API'],
+        ];
+
+        if ($type === 'model') {
+            $definition['model'] = $info['Name'];
+            $definition['primary_key'] = $this->resolvePrimaryKey($info['Name']);
+            $definition['operations'] = $this->buildModelOperations($resourceName, $info['Name']);
+            $definition['schema'] = [
+                'url' => $this->getAbsoluteUrl($this->buildEndpoint($resourceName) . '/schema'),
+            ];
+
+            if ($includeSchemaFields) {
+                $definition['schema']['fields'] = $this->buildModelSchema($info['Name']);
+            }
+        } else {
+            $definition['operations'] = $this->buildCustomOperations($info['API'], $resourceName);
+        }
+
+        return $definition;
+    }
+
+    private function buildResourcesSummary(): array
+    {
+        $summary = [];
+        foreach ($this->getDiscoverableResources() as $resourceName => $info) {
+            $definition = $this->buildResourceDefinition($resourceName, $info, false);
+            if (null === $definition) {
+                continue;
+            }
+
+            $item = [
+                'name' => $definition['name'],
+                'type' => $definition['type'],
+                'endpoint' => $definition['endpoint'],
+                'operations' => array_map(function (array $operation): string {
+                    return $operation['method'] . ' ' . $operation['path'];
+                }, $definition['operations']),
+            ];
+
+            if (isset($definition['model'])) {
+                $item['model'] = $definition['model'];
+                $item['schema'] = $definition['schema']['url'] ?? null;
+            }
+
+            $summary[] = $item;
+        }
+
+        return $summary;
+    }
+
+    private function buildCustomOperations(string $apiClass, string $resourceName): array
+    {
+        $endpoint = $this->getAbsoluteUrl($this->buildEndpoint($resourceName));
+        $operations = [];
+        foreach (['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as $method) {
+            $methodName = 'do' . $method;
+            if (!method_exists($apiClass, $methodName)) {
+                continue;
+            }
+
+            $operations[] = [
+                'name' => strtolower($method),
+                'method' => $method,
+                'path' => $endpoint,
+                'description' => 'Consulta el controlador ' . $apiClass . ' para conocer parámetros y formato.',
+            ];
+        }
+
+        if (empty($operations)) {
+            $operations[] = [
+                'name' => 'run',
+                'method' => 'CUSTOM',
+                'path' => $endpoint,
+                'description' => 'El controlador ' . $apiClass . ' gestiona este recurso con una lógica específica.',
+            ];
+        }
+
+        return $operations;
+    }
+
+    private function getAbsoluteUrl(string $path): string
+    {
+        $host = $this->request->host();
+        if (empty($host)) {
+            return $path;
+        }
+
+        $scheme = $this->request->isSecure() ? 'https' : 'http';
+        if ($path[0] !== '/') {
+            $path = '/' . $path;
+        }
+
+        return $scheme . '://' . $host . $path;
+    }
+
+    private function getBasePath(): string
+    {
+        return '/api/v' . ApiController::API_VERSION;
+    }
+
+    private function getDiscoverableResources(): array
+    {
+        $resources = $this->getResourcesMap();
+        unset($resources[self::RESOURCE_NAME]);
+        return $resources;
+    }
+
+    private function getQueryDocumentation(): array
+    {
+        return [
+            'filter[campo]' => 'Filtra resultados. Permite sufijos _like, _gt, _gte, _lt, _lte, _neq, _null, _notnull.',
+            'operation[campo]' => 'Sobrescribe la operación lógica (AND/OR) para filtros específicos.',
+            'sort[campo]' => 'Ordena por el campo indicado con valores ASC o DESC.',
+            'limit' => 'Número máximo de filas devueltas (por defecto 50).',
+            'offset' => 'Desplazamiento inicial para paginación.',
+        ];
+    }
+
+    private function getResourcesMap(): array
+    {
+        if (null !== $this->cachedResources) {
+            return $this->cachedResources;
+        }
+
+        $resources = [];
+        $folder = Tools::folder('Dinamic', 'Lib', 'API');
+        if (!is_dir($folder)) {
+            $this->cachedResources = [];
+            return $this->cachedResources;
+        }
+
+        foreach (Tools::folderScan($folder, false) as $fileName) {
+            if (substr($fileName, -4) !== '.php') {
+                continue;
+            }
+
+            $className = substr('\\FacturaScripts\\Dinamic\\Lib\\API\\' . $fileName, 0, -4);
+            if (!class_exists($className)) {
+                continue;
+            }
+
+            $apiClass = new $className($this->response, $this->request, []);
+            if (!method_exists($apiClass, 'getResources')) {
+                continue;
+            }
+
+            foreach ($apiClass->getResources() as $resourceName => $definition) {
+                $resources[$resourceName] = $definition;
+            }
+        }
+
+        $this->cachedResources = $resources;
+        return $this->cachedResources;
+    }
+
+    private function resolvePrimaryKey(string $modelName): ?string
+    {
+        $class = '\\FacturaScripts\\Dinamic\\Model\\' . $modelName;
+        if (!class_exists($class)) {
+            return null;
+        }
+
+        try {
+            $model = new $class();
+        } catch (Exception $exception) {
+            Tools::log()->warning('Unable to instantiate model for MCP primary key: ' . $modelName . ' -> ' . $exception->getMessage());
+            return null;
+        }
+
+        return $model->primaryColumn();
+    }
+
+    private function resolveResourceType(string $apiClass): string
+    {
+        return is_a($apiClass, APIModel::class, true) ? 'model' : 'custom';
+    }
+
+    private function respondWithResources(): bool
+    {
+        if (empty($this->params)) {
+            $this->returnResult(['resources' => $this->buildResourcesSummary()]);
+            return true;
+        }
+
+        $resourceName = array_shift($this->params);
+        if ('schema' === ($this->params[0] ?? '')) {
+            return $this->respondWithSchema($resourceName);
+        }
+
+        $resources = $this->getResourcesMap();
+        if (!isset($resources[$resourceName])) {
+            $this->setError(Tools::trans('record-not-found'), null, Response::HTTP_NOT_FOUND);
+            return false;
+        }
+
+        $definition = $this->buildResourceDefinition($resourceName, $resources[$resourceName]);
+        if (null === $definition) {
+            $this->setError('resource-definition-error');
+            return false;
+        }
+
+        $this->returnResult($definition);
+        return true;
+    }
+
+    private function respondWithSchema(string $resourceName): bool
+    {
+        $resources = $this->getResourcesMap();
+        if (!isset($resources[$resourceName])) {
+            $this->setError(Tools::trans('record-not-found'), null, Response::HTTP_NOT_FOUND);
+            return false;
+        }
+
+        $info = $resources[$resourceName];
+        if ($this->resolveResourceType($info['API']) !== 'model') {
+            $this->setError('schema-not-available', null, Response::HTTP_BAD_REQUEST);
+            return false;
+        }
+
+        $fields = $this->buildModelSchema($info['Name']);
+        $this->returnResult([
+            'name' => $resourceName,
+            'model' => $info['Name'],
+            'schema' => $fields,
+        ]);
+        return true;
+    }
+
+    /**
+     * Procesa una petición JSON-RPC, compatible con peticiones individuales o lotes.
+     *
+     * @param array $payload
+     *
+     * @return array|null
+     */
+    private function handleJsonRpcPayload(array $payload): ?array
+    {
+        if ($this->isSequentialArray($payload)) {
+            if (empty($payload)) {
+                return [$this->buildRpcError(null, self::ERROR_INVALID_REQUEST, 'Batch must contain at least one request.')];
+            }
+
+            $responses = [];
+            foreach ($payload as $entry) {
+                if (!is_array($entry)) {
+                    $responses[] = $this->buildRpcError(null, self::ERROR_INVALID_REQUEST, 'Each batch entry must be an object.');
+                    continue;
+                }
+
+                $response = $this->handleJsonRpcRequest($entry);
+                if (null !== $response) {
+                    $responses[] = $response;
+                }
+            }
+
+            return empty($responses) ? null : $responses;
+        }
+
+        return $this->handleJsonRpcRequest($payload);
+    }
+
+    private function handleJsonRpcRequest(array $request): ?array
+    {
+        $hasId = array_key_exists('id', $request);
+        $id = $hasId ? $request['id'] : null;
+        $jsonrpc = (string)($request['jsonrpc'] ?? '');
+        $method = (string)($request['method'] ?? '');
+
+        if ($jsonrpc !== self::JSON_RPC_VERSION || $method === '') {
+            return $this->buildRpcError($id, self::ERROR_INVALID_REQUEST, 'Invalid JSON-RPC request.');
+        }
+
+        $params = $request['params'] ?? [];
+        if (!is_array($params)) {
+            return $this->buildRpcError($id, self::ERROR_INVALID_PARAMS, 'Params must be an object or array.');
+        }
+
+        try {
+            $result = $this->executeRpcMethod(str_replace('.', '/', strtolower($method)), $params);
+            if (!$hasId) {
+                return null;
+            }
+
+            return $this->buildRpcResult($id, $result);
+        } catch (RpcException $exception) {
+            if (!$hasId) {
+                Tools::log()->warning('mcp-rpc-notification-error', [
+                    'method' => $method,
+                    'code' => $exception->getCode(),
+                    'message' => $exception->getMessage(),
+                ]);
+                return null;
+            }
+
+            return $this->buildRpcError($id, $exception->getCode(), $exception->getMessage(), $exception->getData());
+        } catch (Exception $exception) {
+            Tools::log()->warning('mcp-rpc-exception', ['method' => $method, 'message' => $exception->getMessage()]);
+            if (!$hasId) {
+                return null;
+            }
+
+            return $this->buildRpcError($id, self::ERROR_INTERNAL_ERROR, 'Internal error.', [
+                'message' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    private function buildRpcError($id, int $code, string $message, $data = null): array
+    {
+        $error = [
+            'code' => $code,
+            'message' => $message,
+        ];
+
+        if (null !== $data) {
+            $error['data'] = $data;
+        }
+
+        return [
+            'jsonrpc' => self::JSON_RPC_VERSION,
+            'id' => $id,
+            'error' => $error,
+        ];
+    }
+
+    private function buildRpcResult($id, $result): array
+    {
+        return [
+            'jsonrpc' => self::JSON_RPC_VERSION,
+            'id' => $id,
+            'result' => $result,
+        ];
+    }
+
+    private function executeRpcMethod(string $method, array $params)
+    {
+        switch ($method) {
+            case 'ping':
+            case 'server/ping':
+                return ['pong' => true];
+
+            case 'server/info':
+                return $this->buildIndexDocument();
+
+            case 'session/create':
+                return $this->createSession($params);
+
+            case 'session/refresh':
+                return $this->refreshSession($params);
+
+            case 'session/close':
+                return $this->closeSession($params);
+
+            case 'resources/list':
+                return ['resources' => $this->buildResourcesSummary()];
+
+            case 'resources/get':
+                $resource = (string)($params['name'] ?? $params['resource'] ?? '');
+                if ($resource === '') {
+                    throw new RpcException(self::ERROR_INVALID_PARAMS, 'Missing resource name.');
+                }
+
+                [$resourceKey, $info] = $this->getResourceEntry($resource);
+                $definition = $this->buildResourceDefinition($resourceKey, $info);
+                if (null === $definition) {
+                    throw new RpcException(self::ERROR_RESOURCE_NOT_FOUND, 'Resource definition unavailable.', ['resource' => $resource]);
+                }
+
+                return $definition;
+
+            case 'resources/schema':
+                $resource = (string)($params['name'] ?? $params['resource'] ?? '');
+                if ($resource === '') {
+                    throw new RpcException(self::ERROR_INVALID_PARAMS, 'Missing resource name.');
+                }
+
+                [$resourceKey, $info] = $this->ensureModelResource($resource);
+                $fields = $this->buildModelSchema($info['Name']);
+
+                return [
+                    'name' => $resourceKey,
+                    'model' => $info['Name'],
+                    'primary_key' => $this->resolvePrimaryKey($info['Name']),
+                    'schema' => $fields,
+                ];
+
+            case 'resources/custom':
+                return ['resources' => $this->buildCustomResources()];
+
+            case 'resources/query':
+                $resource = (string)($params['resource'] ?? $params['name'] ?? '');
+                if ($resource === '') {
+                    throw new RpcException(self::ERROR_INVALID_PARAMS, 'Missing resource name.');
+                }
+
+                return $this->runModelQuery($resource, $params);
+
+            case 'tools/list':
+                return ['tools' => $this->describeTools()];
+
+            case 'tools/call':
+                return $this->handleToolCall($params);
+
+            default:
+                throw new RpcException(self::ERROR_METHOD_NOT_FOUND, 'Method not found.', ['method' => $method]);
+        }
+    }
+
+    private function createSession(array $params): array
+    {
+        $requestedId = (string)($params['session_id'] ?? '');
+        if ($requestedId !== '') {
+            $session = $this->getSessionData($requestedId);
+            if (!empty($session)) {
+                return $this->buildSessionResult($requestedId, $session);
+            }
+        }
+
+        $sessionId = $this->generateSessionId();
+        $session = [
+            'id' => $sessionId,
+            'created_at' => gmdate('c'),
+            'last_seen_at' => gmdate('c'),
+            'expires_at' => gmdate('c', time() + self::SESSION_TTL),
+        ];
+
+        $this->persistSession($sessionId, $session);
+
+        return $this->buildSessionResult($sessionId, $session);
+    }
+
+    private function refreshSession(array $params): array
+    {
+        $sessionId = (string)($params['session_id'] ?? '');
+        if ($sessionId === '') {
+            throw new RpcException(self::ERROR_INVALID_PARAMS, 'Missing session identifier.');
+        }
+
+        $session = $this->getSessionData($sessionId);
+        if (empty($session)) {
+            throw new RpcException(self::ERROR_RESOURCE_NOT_FOUND, 'Session not found.', ['session_id' => $sessionId]);
+        }
+
+        $session['last_seen_at'] = gmdate('c');
+        $session['expires_at'] = gmdate('c', time() + self::SESSION_TTL);
+        $this->persistSession($sessionId, $session);
+
+        return $this->buildSessionResult($sessionId, $session);
+    }
+
+    private function closeSession(array $params): array
+    {
+        $sessionId = (string)($params['session_id'] ?? '');
+        if ($sessionId === '') {
+            throw new RpcException(self::ERROR_INVALID_PARAMS, 'Missing session identifier.');
+        }
+
+        Cache::delete($this->buildSessionKey($sessionId));
+
+        return [
+            'session' => [
+                'id' => $sessionId,
+                'closed_at' => gmdate('c'),
+            ],
+        ];
+    }
+
+    private function buildSessionResult(string $sessionId, array $session): array
+    {
+        return [
+            'session' => [
+                'id' => $sessionId,
+                'created_at' => $session['created_at'] ?? gmdate('c'),
+                'last_seen_at' => $session['last_seen_at'] ?? gmdate('c'),
+                'expires_at' => $session['expires_at'] ?? gmdate('c', time() + self::SESSION_TTL),
+            ],
+            'capabilities' => [
+                'transport' => [
+                    'type' => 'http-jsonrpc',
+                    'endpoint' => $this->getAbsoluteUrl($this->buildEndpoint(self::RESOURCE_NAME)),
+                ],
+                'resources' => [
+                    'list' => true,
+                    'get' => true,
+                    'schema' => true,
+                    'query' => true,
+                    'custom' => true,
+                ],
+                'tools' => [
+                    'model_query' => true,
+                    'model_mutation' => true,
+                ],
+            ],
+            'links' => [
+                'resources' => $this->getAbsoluteUrl($this->buildEndpoint(self::RESOURCE_NAME) . '/resources'),
+                'custom' => $this->getAbsoluteUrl($this->buildEndpoint(self::RESOURCE_NAME) . '/custom'),
+            ],
+        ];
+    }
+
+    private function generateSessionId(): string
+    {
+        try {
+            return bin2hex(random_bytes(16));
+        } catch (Exception $exception) {
+            return uniqid('mcp-', true);
+        }
+    }
+
+    private function getSessionData(string $sessionId): array
+    {
+        $data = Cache::get($this->buildSessionKey($sessionId));
+        if (!is_array($data)) {
+            return [];
+        }
+
+        $expiresAt = $data['expires_at'] ?? null;
+        if (null !== $expiresAt) {
+            $timestamp = strtotime((string)$expiresAt);
+            if (false !== $timestamp && $timestamp <= time()) {
+                Cache::delete($this->buildSessionKey($sessionId));
+                return [];
+            }
+        }
+
+        return $data;
+    }
+
+    private function persistSession(string $sessionId, array $session): void
+    {
+        Cache::set($this->buildSessionKey($sessionId), $session);
+    }
+
+    private function buildSessionKey(string $sessionId): string
+    {
+        return 'mcp-session-' . $sessionId;
+    }
+
+    private function describeTools(): array
+    {
+        return [
+            [
+                'name' => 'model_query',
+                'description' => 'Consulta registros de un recurso de modelo utilizando filtros, ordenaciones y paginación.',
+                'input_schema' => [
+                    'type' => 'object',
+                    'required' => ['resource'],
+                    'properties' => [
+                        'resource' => [
+                            'type' => 'string',
+                            'description' => 'Nombre del recurso (plural) tal y como aparece en resources/list.',
+                        ],
+                        'filter' => [
+                            'type' => 'object',
+                            'additionalProperties' => true,
+                        ],
+                        'operation' => [
+                            'type' => 'object',
+                            'additionalProperties' => [
+                                'type' => 'string',
+                                'enum' => ['AND', 'OR'],
+                            ],
+                        ],
+                        'sort' => [
+                            'type' => 'object',
+                            'additionalProperties' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                        'limit' => [
+                            'type' => 'integer',
+                            'minimum' => 1,
+                            'maximum' => self::MAX_QUERY_LIMIT,
+                        ],
+                        'offset' => [
+                            'type' => 'integer',
+                            'minimum' => 0,
+                        ],
+                    ],
+                ],
+                'output_schema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'resource' => ['type' => 'string'],
+                        'model' => ['type' => 'string'],
+                        'primary_key' => ['type' => 'string'],
+                        'rows' => [
+                            'type' => 'array',
+                            'items' => ['type' => 'object'],
+                        ],
+                        'total' => ['type' => 'integer'],
+                        'limit' => ['type' => 'integer'],
+                        'offset' => ['type' => 'integer'],
+                    ],
+                ],
+            ],
+            [
+                'name' => 'model_mutation',
+                'description' => 'Crea, actualiza, recupera o elimina registros de un recurso de modelo.',
+                'input_schema' => [
+                    'type' => 'object',
+                    'required' => ['resource', 'operation'],
+                    'properties' => [
+                        'resource' => [
+                            'type' => 'string',
+                            'description' => 'Nombre del recurso sobre el que se ejecutará la mutación.',
+                        ],
+                        'operation' => [
+                            'type' => 'string',
+                            'enum' => ['create', 'update', 'delete', 'retrieve'],
+                        ],
+                        'record' => [
+                            'type' => 'object',
+                            'description' => 'Datos del registro para create/update.',
+                        ],
+                        'id' => [
+                            'type' => ['string', 'number'],
+                            'description' => 'Identificador del registro cuando aplique.',
+                        ],
+                    ],
+                ],
+                'output_schema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'operation' => ['type' => 'string'],
+                        'record' => ['type' => ['object', 'null']],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function handleToolCall(array $params): array
+    {
+        $toolName = (string)($params['name'] ?? $params['tool'] ?? '');
+        if ($toolName === '') {
+            throw new RpcException(self::ERROR_INVALID_PARAMS, 'Missing tool name.');
+        }
+
+        $arguments = $params['arguments'] ?? $params['params'] ?? [];
+        if (!is_array($arguments)) {
+            throw new RpcException(self::ERROR_INVALID_PARAMS, 'Tool arguments must be an object or array.', ['tool' => $toolName]);
+        }
+
+        switch (strtolower($toolName)) {
+            case 'model_query':
+                $resource = (string)($arguments['resource'] ?? '');
+                if ($resource === '') {
+                    throw new RpcException(self::ERROR_INVALID_PARAMS, 'Missing resource parameter.', ['tool' => $toolName]);
+                }
+
+                $result = $this->runModelQuery($resource, $arguments);
+                return [
+                    'tool' => $toolName,
+                    'result' => $result,
+                ];
+
+            case 'model_mutation':
+                $resource = (string)($arguments['resource'] ?? '');
+                $operation = strtolower((string)($arguments['operation'] ?? ''));
+                if ($resource === '' || $operation === '') {
+                    throw new RpcException(self::ERROR_INVALID_PARAMS, 'Missing resource or operation parameter.', ['tool' => $toolName]);
+                }
+
+                $record = $arguments['record'] ?? $arguments['data'] ?? [];
+                if (!is_array($record)) {
+                    $record = [];
+                }
+
+                switch ($operation) {
+                    case 'create':
+                        $created = $this->createModelRecord($resource, $record);
+                        return [
+                            'tool' => $toolName,
+                            'result' => [
+                                'operation' => 'create',
+                                'record' => $created,
+                            ],
+                        ];
+
+                    case 'update':
+                        $updated = $this->updateModelRecord($resource, array_merge($arguments, ['record' => $record]));
+                        return [
+                            'tool' => $toolName,
+                            'result' => [
+                                'operation' => 'update',
+                                'record' => $updated,
+                            ],
+                        ];
+
+                    case 'delete':
+                        $deleted = $this->deleteModelRecord($resource, $arguments);
+                        return [
+                            'tool' => $toolName,
+                            'result' => [
+                                'operation' => 'delete',
+                                'record' => $deleted,
+                            ],
+                        ];
+
+                    case 'retrieve':
+                        $fetched = $this->retrieveModelRecord($resource, $arguments);
+                        return [
+                            'tool' => $toolName,
+                            'result' => [
+                                'operation' => 'retrieve',
+                                'record' => $fetched,
+                            ],
+                        ];
+
+                    default:
+                        throw new RpcException(self::ERROR_INVALID_PARAMS, 'Unsupported mutation operation.', [
+                            'tool' => $toolName,
+                            'operation' => $operation,
+                        ]);
+                }
+
+            default:
+                throw new RpcException(self::ERROR_METHOD_NOT_FOUND, 'Tool not found.', ['tool' => $toolName]);
+        }
+    }
+
+    private function runModelQuery(string $resourceName, array $params): array
+    {
+        [$resourceKey, $info] = $this->ensureModelResource($resourceName);
+        $model = $this->instantiateModel($info['Name']);
+        $modelClass = get_class($model);
+        $primaryKey = $this->resolvePrimaryKey($info['Name']) ?? 'id';
+
+        $identifier = $this->resolveRecordIdentifier($params, $primaryKey, false);
+        if (null !== $identifier) {
+            $recordModel = $this->instantiateModel($info['Name']);
+            if (false === $recordModel->loadFromCode($identifier)) {
+                return [
+                    'resource' => $resourceKey,
+                    'model' => $info['Name'],
+                    'primary_key' => $primaryKey,
+                    'rows' => [],
+                    'total' => 0,
+                    'limit' => 1,
+                    'offset' => 0,
+                ];
+            }
+
+            return [
+                'resource' => $resourceKey,
+                'model' => $info['Name'],
+                'primary_key' => $primaryKey,
+                'rows' => [$recordModel->toArray()],
+                'total' => 1,
+                'limit' => 1,
+                'offset' => 0,
+            ];
+        }
+
+        $filter = $this->normalizeFilterInput($params['filter'] ?? []);
+        $operation = $this->normalizeOperationInput($params['operation'] ?? []);
+        $sort = $this->normalizeSort($params['sort'] ?? []);
+        $limit = $this->normalizeLimit($params['limit'] ?? 50);
+        $offset = max(0, (int)($params['offset'] ?? 0));
+
+        $where = $this->buildWhereFromFilters($filter, $operation);
+
+        $rows = [];
+        foreach ($modelClass::all($where, $sort, $offset, $limit) as $record) {
+            $rows[] = $record->toArray();
+        }
+
+        $total = $modelClass::count($where);
+
+        return [
+            'resource' => $resourceKey,
+            'model' => $info['Name'],
+            'primary_key' => $primaryKey,
+            'rows' => $rows,
+            'total' => $total,
+            'limit' => $limit,
+            'offset' => $offset,
+        ];
+    }
+
+    private function ensureModelResource(string $resourceName): array
+    {
+        [$resourceKey, $info] = $this->getResourceEntry($resourceName);
+        if ($this->resolveResourceType($info['API']) !== 'model') {
+            throw new RpcException(self::ERROR_INVALID_PARAMS, 'Resource is not a model resource.', ['resource' => $resourceName]);
+        }
+
+        return [$resourceKey, $info];
+    }
+
+    private function getResourceEntry(string $resourceName): array
+    {
+        $resources = $this->getResourcesMap();
+        if (isset($resources[$resourceName])) {
+            return [$resourceName, $resources[$resourceName]];
+        }
+
+        foreach ($resources as $key => $info) {
+            if (strcasecmp($key, $resourceName) === 0) {
+                return [$key, $info];
+            }
+
+            if (isset($info['Name']) && strcasecmp($info['Name'], $resourceName) === 0) {
+                return [$key, $info];
+            }
+        }
+
+        throw new RpcException(self::ERROR_RESOURCE_NOT_FOUND, 'Resource not found.', ['resource' => $resourceName]);
+    }
+
+    private function instantiateModel(string $modelName): ModelClass
+    {
+        $class = '\\FacturaScripts\\Dinamic\\Model\\' . $modelName;
+        if (!class_exists($class)) {
+            throw new RpcException(self::ERROR_INTERNAL_ERROR, 'Model class not found.', ['model' => $modelName]);
+        }
+
+        $model = new $class();
+        if (!$model instanceof ModelClass) {
+            throw new RpcException(self::ERROR_INTERNAL_ERROR, 'Invalid model class.', ['model' => $modelName]);
+        }
+
+        return $model;
+    }
+
+    private function normalizeFilterInput($filters): array
+    {
+        if (!is_array($filters)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($filters as $key => $value) {
+            if (!is_string($key)) {
+                continue;
+            }
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeOperationInput($operations): array
+    {
+        if (!is_array($operations)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($operations as $key => $value) {
+            if (!is_string($key) || !is_string($value)) {
+                continue;
+            }
+
+            $normalized[$key] = strtoupper($value) === 'OR' ? 'OR' : 'AND';
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeSort($sort): array
+    {
+        if (!is_array($sort)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($sort as $key => $value) {
+            if (is_int($key) && is_string($value)) {
+                $normalized[$value] = 'ASC';
+                continue;
+            }
+
+            if (!is_string($key) || !is_string($value)) {
+                continue;
+            }
+
+            $direction = strtoupper($value) === 'DESC' ? 'DESC' : 'ASC';
+            $normalized[$key] = $direction;
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeLimit($limit): int
+    {
+        $value = (int)$limit;
+        if ($value <= 0) {
+            $value = 50;
+        }
+
+        return min($value, self::MAX_QUERY_LIMIT);
+    }
+
+    private function buildWhereFromFilters(array $filter, array $operation, string $defaultOperation = 'AND'): array
+    {
+        $where = [];
+        foreach ($filter as $key => $value) {
+            $field = $key;
+            $operator = '=';
+
+            switch (substr($key, -3)) {
+                case '_gt':
+                    $field = substr($key, 0, -3);
+                    $operator = '>';
+                    break;
+
+                case '_is':
+                    $field = substr($key, 0, -3);
+                    $operator = 'IS';
+                    break;
+
+                case '_lt':
+                    $field = substr($key, 0, -3);
+                    $operator = '<';
+                    break;
+            }
+
+            switch (substr($key, -4)) {
+                case '_gte':
+                    $field = substr($key, 0, -4);
+                    $operator = '>=';
+                    break;
+
+                case '_lte':
+                    $field = substr($key, 0, -4);
+                    $operator = '<=';
+                    break;
+
+                case '_neq':
+                    $field = substr($key, 0, -4);
+                    $operator = '!=';
+                    break;
+            }
+
+            if (substr($key, -5) == '_null') {
+                $field = substr($key, 0, -5);
+                $operator = 'IS';
+                $value = null;
+            } elseif (substr($key, -8) == '_notnull') {
+                $field = substr($key, 0, -8);
+                $operator = 'IS NOT';
+                $value = null;
+            }
+
+            if (substr($key, -5) == '_like') {
+                $field = substr($key, 0, -5);
+                $operator = 'LIKE';
+            } elseif (substr($key, -6) == '_isnot') {
+                $field = substr($key, 0, -6);
+                $operator = 'IS NOT';
+            }
+
+            $logic = $operation[$key] ?? $defaultOperation;
+            $logic = strtoupper($logic) === 'OR' ? 'OR' : 'AND';
+
+            $where[] = new DataBaseWhere($field, $value, $operator, $logic);
+        }
+
+        return $where;
+    }
+
+    private function createModelRecord(string $resourceName, array $record): array
+    {
+        [, $info] = $this->ensureModelResource($resourceName);
+        $model = $this->instantiateModel($info['Name']);
+        $this->fillModel($model, $record);
+
+        MiniLog::clear();
+        if (false === $model->save()) {
+            $messages = $this->collectLogMessages();
+            throw new RpcException(self::ERROR_OPERATION_FAILED, 'record-save-error', [
+                'messages' => $messages,
+                'record' => $record,
+            ]);
+        }
+
+        MiniLog::clear();
+        return $model->toArray();
+    }
+
+    private function updateModelRecord(string $resourceName, array $arguments): array
+    {
+        [, $info] = $this->ensureModelResource($resourceName);
+        $model = $this->instantiateModel($info['Name']);
+        $primaryKey = $this->resolvePrimaryKey($info['Name']) ?? 'id';
+
+        $record = $arguments['record'] ?? $arguments['data'] ?? [];
+        if (!is_array($record)) {
+            throw new RpcException(self::ERROR_INVALID_PARAMS, 'Record payload must be an object.', ['resource' => $resourceName]);
+        }
+
+        $identifier = $this->resolveRecordIdentifier($arguments + ['record' => $record], $primaryKey);
+        if (false === $model->loadFromCode($identifier)) {
+            throw new RpcException(self::ERROR_RESOURCE_NOT_FOUND, 'Record not found.', [
+                'resource' => $resourceName,
+                'id' => $identifier,
+            ]);
+        }
+
+        $this->fillModel($model, $record);
+
+        MiniLog::clear();
+        if (false === $model->save()) {
+            $messages = $this->collectLogMessages();
+            throw new RpcException(self::ERROR_OPERATION_FAILED, 'record-save-error', [
+                'messages' => $messages,
+                'id' => $identifier,
+            ]);
+        }
+
+        MiniLog::clear();
+        return $model->toArray();
+    }
+
+    private function deleteModelRecord(string $resourceName, array $arguments): array
+    {
+        [, $info] = $this->ensureModelResource($resourceName);
+        $model = $this->instantiateModel($info['Name']);
+        $primaryKey = $this->resolvePrimaryKey($info['Name']) ?? 'id';
+
+        $identifier = $this->resolveRecordIdentifier($arguments, $primaryKey);
+        if (false === $model->loadFromCode($identifier)) {
+            throw new RpcException(self::ERROR_RESOURCE_NOT_FOUND, 'Record not found.', [
+                'resource' => $resourceName,
+                'id' => $identifier,
+            ]);
+        }
+
+        $data = $model->toArray();
+
+        MiniLog::clear();
+        if (false === $model->delete()) {
+            $messages = $this->collectLogMessages();
+            throw new RpcException(self::ERROR_OPERATION_FAILED, 'record-delete-error', [
+                'messages' => $messages,
+                'id' => $identifier,
+            ]);
+        }
+
+        MiniLog::clear();
+        return $data;
+    }
+
+    private function retrieveModelRecord(string $resourceName, array $arguments): array
+    {
+        [, $info] = $this->ensureModelResource($resourceName);
+        $model = $this->instantiateModel($info['Name']);
+        $primaryKey = $this->resolvePrimaryKey($info['Name']) ?? 'id';
+
+        $identifier = $this->resolveRecordIdentifier($arguments, $primaryKey);
+        if (false === $model->loadFromCode($identifier)) {
+            throw new RpcException(self::ERROR_RESOURCE_NOT_FOUND, 'Record not found.', [
+                'resource' => $resourceName,
+                'id' => $identifier,
+            ]);
+        }
+
+        return $model->toArray();
+    }
+
+    private function resolveRecordIdentifier(array $arguments, string $primaryKey, bool $required = true): ?string
+    {
+        if (isset($arguments['id']) && $arguments['id'] !== '') {
+            return (string)$arguments['id'];
+        }
+
+        if (isset($arguments[$primaryKey]) && $arguments[$primaryKey] !== '') {
+            return (string)$arguments[$primaryKey];
+        }
+
+        $record = $arguments['record'] ?? $arguments['data'] ?? [];
+        if (is_array($record) && isset($record[$primaryKey]) && $record[$primaryKey] !== '') {
+            return (string)$record[$primaryKey];
+        }
+
+        if ($required) {
+            throw new RpcException(self::ERROR_INVALID_PARAMS, 'Missing record identifier.', ['primary_key' => $primaryKey]);
+        }
+
+        return null;
+    }
+
+    private function fillModel(ModelClass $model, array $data): void
+    {
+        $fields = $model->getModelFields();
+        foreach ($data as $key => $value) {
+            if (isset($fields[$key])) {
+                $model->{$key} = $value;
+            }
+        }
+    }
+
+    private function collectLogMessages(): array
+    {
+        $logs = MiniLog::read('', ['critical', 'error', 'warning', 'notice']);
+        $messages = [];
+        foreach ($logs as $log) {
+            if (!empty($log['message'])) {
+                $messages[] = $log['message'];
+            }
+        }
+        MiniLog::clear();
+
+        return array_values(array_unique($messages));
+    }
+
+    private function isSequentialArray(array $array): bool
+    {
+        $index = 0;
+        foreach ($array as $key => $value) {
+            if ($key !== $index) {
+                return false;
+            }
+            ++$index;
+        }
+
+        return true;
+    }
+}

--- a/Plugins/McpApi/Lib/API/Mcp.php
+++ b/Plugins/McpApi/Lib/API/Mcp.php
@@ -38,9 +38,9 @@ use FacturaScripts\Plugins\McpApi\Lib\Mcp\RpcException;
 class Mcp extends APIResourceClass
 {
     private const RESOURCE_NAME = 'mcp';
-    private const SPEC_VERSION = '1.0.0';
+    public const SPEC_VERSION = '1.0.0';
     private const JSON_RPC_VERSION = '2.0';
-    private const SESSION_TTL = 3600;
+    public const SESSION_TTL = 3600;
     private const MAX_QUERY_LIMIT = 200;
     private const ERROR_PARSE_ERROR = -32700;
     private const ERROR_INVALID_REQUEST = -32600;

--- a/Plugins/McpApi/Lib/Mcp/RpcException.php
+++ b/Plugins/McpApi/Lib/Mcp/RpcException.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2025 Carlos Garcia Gomez <carlos@facturascripts.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Plugins\McpApi\Lib\Mcp;
+
+use Exception;
+
+final class RpcException extends Exception
+{
+    /** @var mixed */
+    private $data;
+
+    public function __construct(int $code, string $message, $data = null)
+    {
+        parent::__construct($message, $code);
+        $this->data = $data;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+}

--- a/Plugins/McpApi/Lib/OAuth/TokenBroker.php
+++ b/Plugins/McpApi/Lib/OAuth/TokenBroker.php
@@ -1,0 +1,183 @@
+<?php
+namespace FacturaScripts\Plugins\McpApi\Lib\OAuth;
+
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Cache;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Dinamic\Model\ApiKey;
+
+class TokenBroker
+{
+    private const CODE_PREFIX = 'mcp-oauth-code-';
+    private const TOKEN_PREFIX = 'mcp-oauth-access-';
+    private const CODE_TTL = 300;
+    private const ACCESS_TTL = 3600;
+
+    /**
+     * @return array{api_key:string,label:string,full_access:bool,id:?int}|null
+     */
+    public static function validateApiKey(string $token): ?array
+    {
+        $token = trim($token);
+        if ($token === '') {
+            return null;
+        }
+
+        if ($token === (string)Tools::config('api_key')) {
+            return [
+                'api_key' => $token,
+                'label' => 'config-api-key',
+                'full_access' => true,
+                'id' => null,
+            ];
+        }
+
+        $apiKey = new ApiKey();
+        $where = [
+            new DataBaseWhere('apikey', $token),
+            new DataBaseWhere('enabled', true),
+        ];
+
+        if (false === $apiKey->loadWhere($where)) {
+            return null;
+        }
+
+        return [
+            'api_key' => $apiKey->apikey,
+            'label' => $apiKey->nick ?: ($apiKey->description ?: 'api-key'),
+            'full_access' => (bool)$apiKey->fullaccess,
+            'id' => $apiKey->id,
+        ];
+    }
+
+    /**
+     * @param array{api_key:string,label:string,full_access:bool,id:?int} $identity
+     * @param string[] $scopes
+     */
+    public static function issueAuthorizationCode(string $clientId, array $identity, string $redirectUri, ?string $codeChallenge, ?string $challengeMethod, array $scopes = []): string
+    {
+        $code = self::randomToken();
+        $method = strtoupper($challengeMethod ?? 'plain');
+        if (!in_array($method, ['PLAIN', 'S256'], true)) {
+            $method = 'PLAIN';
+        }
+
+        $record = [
+            'client_id' => $clientId,
+            'identity' => $identity,
+            'redirect_uri' => $redirectUri,
+            'code_challenge' => $codeChallenge,
+            'code_challenge_method' => $method,
+            'scopes' => $scopes,
+            'created_at' => time(),
+            'expires_at' => time() + self::CODE_TTL,
+        ];
+
+        Cache::set(self::CODE_PREFIX . $code, $record);
+        return $code;
+    }
+
+    /**
+     * @return array{access_token:string,token_type:string,expires_in:int,scope:string}
+     */
+    public static function exchangeCode(string $code, string $clientId, string $redirectUri, ?string $codeVerifier): ?array
+    {
+        $payload = Cache::get(self::CODE_PREFIX . $code);
+        Cache::delete(self::CODE_PREFIX . $code);
+        if (!is_array($payload)) {
+            return null;
+        }
+
+        if (($payload['client_id'] ?? '') !== $clientId) {
+            return null;
+        }
+
+        if (($payload['redirect_uri'] ?? '') !== $redirectUri) {
+            return null;
+        }
+
+        if (!self::isCodeFresh($payload)) {
+            return null;
+        }
+
+        $challenge = $payload['code_challenge'] ?? null;
+        if ($challenge) {
+            $method = strtoupper($payload['code_challenge_method'] ?? 'PLAIN');
+            if (null === $codeVerifier || $codeVerifier === '') {
+                return null;
+            }
+
+            if ($method === 'S256') {
+                $expected = rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '=');
+            } else {
+                $expected = $codeVerifier;
+            }
+
+            if (!hash_equals($challenge, $expected)) {
+                return null;
+            }
+        }
+
+        $token = self::randomToken();
+        $identity = $payload['identity'];
+        $record = [
+            'api_key' => $identity['api_key'],
+            'client_id' => $clientId,
+            'label' => $identity['label'],
+            'full_access' => $identity['full_access'],
+            'scopes' => $payload['scopes'],
+            'expires_at' => time() + self::ACCESS_TTL,
+        ];
+
+        Cache::set(self::TOKEN_PREFIX . $token, $record);
+
+        return [
+            'access_token' => $token,
+            'token_type' => 'Bearer',
+            'expires_in' => self::ACCESS_TTL,
+            'scope' => implode(' ', $payload['scopes']),
+        ];
+    }
+
+    public static function resolveBearerToken(string $authorizationHeader): ?string
+    {
+        if (!preg_match('/^Bearer\s+(\S+)$/i', trim($authorizationHeader), $matches)) {
+            return null;
+        }
+
+        $token = $matches[1];
+        $record = Cache::get(self::TOKEN_PREFIX . $token);
+        if (!is_array($record)) {
+            return null;
+        }
+
+        if (($record['expires_at'] ?? 0) < time()) {
+            Cache::delete(self::TOKEN_PREFIX . $token);
+            return null;
+        }
+
+        return $record['api_key'] ?? null;
+    }
+
+    /**
+     * @param array{expires_at?:int}|null $payload
+     */
+    private static function isCodeFresh(?array $payload): bool
+    {
+        if (null === $payload) {
+            return false;
+        }
+
+        $expiresAt = $payload['expires_at'] ?? 0;
+        if ($expiresAt < time()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function randomToken(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+}

--- a/Plugins/McpApi/README.md
+++ b/Plugins/McpApi/README.md
@@ -1,6 +1,10 @@
 # Plugin MCP API
 
-Este plugin añade una implementación completa del protocolo Model Context Protocol (MCP) sobre la API REST de FacturaScripts. Publica un punto de descubrimiento HTTP tradicional y un endpoint JSON-RPC que permite a un agente de IA inspeccionar los recursos disponibles, consultar datos y ejecutar operaciones de escritura de forma estructurada.
+Este plugin añade una implementación completa del protocolo Model Context Protocol (MCP) sobre la API REST de FacturaScripts. Publica un punto de descubrimiento HTTP tradicional, un manifiesto compatible con clientes MCP modernos y un endpoint JSON-RPC que permite a un agente de IA inspeccionar los recursos disponibles, consultar datos y ejecutar operaciones de escritura de forma estructurada.
+
+## Descubrimiento MCP
+
+- `GET /.well-known/mcp.json`: manifiesto con la versión del protocolo soportada, endpoints disponibles, capacidades y metadatos de autenticación para agentes externos (por ejemplo ChatGPT). El manifiesto incluye los enlaces al flujo OAuth 2.0 y al endpoint JSON-RPC.
 
 ## Endpoints REST
 
@@ -48,7 +52,13 @@ Las solicitudes JSON-RPC sin campo `id` se interpretan como notificaciones y dev
 
 ## Autenticación
 
-Los endpoints mantienen las mismas reglas de autenticación que el resto de la API. Debes enviar la cabecera `X-Auth-Token` (o `Token`) con una clave generada en _Administrador → Usuarios → API_.
+FacturaScripts sigue aceptando la cabecera `X-Auth-Token` (o `Token`) para integraciones manuales, pero el plugin incorpora además un flujo OAuth 2.0 de tipo _authorization code_ para que los agentes MCP puedan obtener tokens compatibles con `Authorization: Bearer`.
+
+1. **Inicio del flujo:** registra `https://<tu-dominio>/mcp/oauth/authorize` como URL de autorización y `https://<tu-dominio>/mcp/oauth/token` como endpoint de tokens. Cuando el cliente redirija al navegador, introduce la clave API que quieras delegar.
+2. **Intercambio de código:** el endpoint `/mcp/oauth/token` acepta peticiones `application/x-www-form-urlencoded` con `grant_type=authorization_code`, `code`, `client_id`, `redirect_uri` y, si procede, `code_verifier` (PKCE).
+3. **Uso de tokens:** cada acceso emitido envuelve la clave API original y expira a la hora. El cliente debe incluirlo en `Authorization: Bearer <token>` al llamar a `/api/v3/mcp`.
+
+> ℹ️ Las claves API pueden generarse desde _Administrador → Usuarios → API_. Puedes revocar un acceso eliminando la clave original o esperando a que caduque el token emitido (1 hora).
 
 ## Instalación
 

--- a/Plugins/McpApi/README.md
+++ b/Plugins/McpApi/README.md
@@ -1,0 +1,59 @@
+# Plugin MCP API
+
+Este plugin añade una implementación completa del protocolo Model Context Protocol (MCP) sobre la API REST de FacturaScripts. Publica un punto de descubrimiento HTTP tradicional y un endpoint JSON-RPC que permite a un agente de IA inspeccionar los recursos disponibles, consultar datos y ejecutar operaciones de escritura de forma estructurada.
+
+## Endpoints REST
+
+Una vez activado el plugin, se publican los siguientes endpoints dentro de la API (`/api/v3`):
+
+- `GET /api/v3/mcp`: documentación general del protocolo MCP para FacturaScripts y enlaces rápidos.
+- `GET /api/v3/mcp/resources`: lista resumida de los recursos disponibles y sus operaciones.
+- `GET /api/v3/mcp/resources/{recurso}`: detalles completos de un recurso, incluyendo operaciones soportadas y enlaces al esquema.
+- `GET /api/v3/mcp/resources/{recurso}/schema`: devuelve el esquema de campos para los recursos de tipo modelo.
+- `GET /api/v3/mcp/custom`: relación de recursos especiales gestionados por controladores específicos.
+
+Los datos devueltos permiten a un cliente construir herramientas automáticas y comprender cómo utilizar la API REST estándar de FacturaScripts.
+
+## Endpoint JSON-RPC
+
+- `POST /api/v3/mcp`: servidor JSON-RPC 2.0. Admite peticiones individuales o en lote.
+
+Métodos disponibles:
+
+- `session/create`, `session/refresh` y `session/close`: gestionan la sesión MCP y devuelven metadatos sobre las capacidades disponibles.
+- `resources/list`, `resources/get`, `resources/schema`, `resources/query`: exponen el inventario de recursos y permiten ejecutar consultas filtradas sobre los modelos nativos.
+- `tools/list`: enumera las herramientas automáticas publicadas (`model_query` y `model_mutation`).
+- `tools/call`: ejecuta las herramientas anteriores para realizar consultas, inserciones, actualizaciones o eliminaciones sin tener que construir manualmente la petición REST.
+
+Ejemplo de petición para consultar clientes con JSON-RPC:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "resources/query",
+  "params": {
+    "resource": "clientes",
+    "filter": {
+      "codgrupo": "EMPRESA"
+    },
+    "limit": 20
+  }
+}
+```
+
+La respuesta contendrá `rows`, `total`, `limit`, `offset`, el nombre del modelo y la clave primaria asociada. Para ejecutar una creación mediante herramientas MCP se puede invocar `tools/call` con `model_mutation` y `operation: "create"`.
+
+Las solicitudes JSON-RPC sin campo `id` se interpretan como notificaciones y devuelven un estado HTTP 204 sin cuerpo. Las sesiones creadas con `session/create` caducan tras una hora de inactividad; ejecuta `session/refresh` para ampliar la expiración si vas a mantener la conversación abierta.
+
+## Autenticación
+
+Los endpoints mantienen las mismas reglas de autenticación que el resto de la API. Debes enviar la cabecera `X-Auth-Token` (o `Token`) con una clave generada en _Administrador → Usuarios → API_.
+
+## Instalación
+
+1. Copia la carpeta del plugin en el directorio `Plugins` de tu instalación de FacturaScripts.
+2. Activa el plugin desde _Administrador → Plugins_.
+3. Vuelve a generar la caché de rutas si es necesario.
+
+Tras activarlo, el endpoint `/api/v3/mcp` estará disponible tanto para peticiones REST como JSON-RPC.

--- a/Plugins/McpApi/facturascripts.ini
+++ b/Plugins/McpApi/facturascripts.ini
@@ -1,0 +1,4 @@
+name = 'McpApi'
+description = 'Implementa un servidor MCP completo con descubrimiento REST y JSON-RPC para automatizar llamadas a la API de FacturaScripts.'
+version = 1.1
+min_version = 2025

--- a/Plugins/McpApi/facturascripts.ini
+++ b/Plugins/McpApi/facturascripts.ini
@@ -1,4 +1,4 @@
 name = 'McpApi'
 description = 'Implementa un servidor MCP completo con descubrimiento REST y JSON-RPC para automatizar llamadas a la API de FacturaScripts.'
-version = 1.1
+version = 2.0
 min_version = 2025


### PR DESCRIPTION
## Summary
- return HTTP 204 for JSON-RPC notifications, logging failures and filtering batch responses
- expire cached MCP sessions automatically, advertise additional capabilities, and harden resource lookups
- document notification handling and session lifetime in the MCP plugin README

## Testing
- php -l Plugins/McpApi/Lib/API/Mcp.php
- php -l Plugins/McpApi/Lib/Mcp/RpcException.php

------
https://chatgpt.com/codex/tasks/task_e_68cc62219424832896377ad2c7bd88e6