### PR TITLE
Add Postman collection for API v3

### DIFF
--- a/docs/openapi/FacturaScripts-2025-API.yaml
+++ b/docs/openapi/FacturaScripts-2025-API.yaml
@@ -1,0 +1,1300 @@
+openapi: 3.0.3
+info:
+  title: FacturaScripts 2025 API
+  version: "2025.0"
+  description: |
+    Especificación OpenAPI de la API REST v3 incluida en FacturaScripts 2025. La API expone recursos
+    CRUD generados automáticamente a partir de los modelos del ERP y controladores especializados
+    para la creación de documentos, gestión de ficheros, pagos, exportaciones y consulta de plugins.
+    Todas las solicitudes deben incluir un token válido en el encabezado `X-Auth-Token`.
+servers:
+  - url: https://{baseUrl}
+    description: Servidor FacturaScripts
+    variables:
+      baseUrl:
+        default: demo.facturascripts.com
+        description: Dominio base (sin ruta) de la instalación
+security:
+  - ApiToken: []
+tags:
+  - name: Descubrimiento
+    description: Recursos para explorar la API y recuperar metadatos de los modelos.
+  - name: Recursos genéricos
+    description: Operaciones CRUD automáticas sobre los modelos publicados en `/Dinamic/Model`.
+  - name: Documentos
+    description: Creación de documentos de venta/compra y emisión de rectificativas.
+  - name: Pagos
+    description: Actualización del estado de cobro/pago de facturas.
+  - name: Archivos
+    description: Endpoints para subir, listar y vincular ficheros y material gráfico de productos.
+  - name: Exportaciones
+    description: Generación de documentos imprimibles en PDF/XLS/CSV.
+  - name: Plugins
+    description: Consulta de la lista de plugins disponibles en la instancia.
+components:
+  securitySchemes:
+    ApiToken:
+      type: apiKey
+      in: header
+      name: X-Auth-Token
+  parameters:
+    ResourceParam:
+      name: resource
+      in: path
+      required: true
+      schema:
+        type: string
+      description: |
+        Nombre pluralizado del recurso. Use `GET /api/3` para descubrir los valores disponibles.
+        Excluye los nombres reservados por los controladores especializados descritos en esta especificación.
+    RecordIdParam:
+      name: recordId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Identificador primario del registro (según el modelo expuesto por la API).
+    LimitParam:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+        default: 50
+      description: Número máximo de registros a devolver.
+    OffsetParam:
+      name: offset
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      description: Índice inicial para paginación basada en desplazamiento.
+    FilterParam:
+      name: filter
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        type: object
+        additionalProperties:
+          oneOf:
+            - type: string
+            - type: number
+            - type: boolean
+      description: |
+        Conjunto de filtros aplicados como cláusulas `WHERE`. Acepte sufijos `_gt`, `_lt`, `_gte`, `_lte`,
+        `_neq`, `_like`, `_null`, `_notnull`, `_is` y `_isnot` para construir operadores específicos.
+    SortParam:
+      name: sort
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        type: object
+        additionalProperties:
+          type: string
+          enum: [ASC, DESC]
+      description: Columnas y sentido de ordenación.
+    OperationParam:
+      name: operation
+      in: query
+      style: deepObject
+      explode: true
+      schema:
+        type: object
+        additionalProperties:
+          type: string
+          enum: [AND, OR]
+      description: Operadores lógicos a aplicar entre filtros (`AND` por defecto).
+    AttachedFileIdParam:
+      name: idfile
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Identificador del archivo adjunto (`idfile`).
+    ProductoImagenIdParam:
+      name: imagenId
+      in: path
+      required: true
+      schema:
+        type: integer
+      description: Identificador de la imagen vinculada al producto.
+    ExportRecordParam:
+      name: documentId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Identificador del documento a exportar.
+    PaymentInvoiceIdParam:
+      name: facturaId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Identificador de la factura a actualizar.
+  headers:
+    TotalCount:
+      description: Número total de registros que cumplen los filtros.
+      schema:
+        type: integer
+        format: int64
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+        data:
+          type: object
+          additionalProperties: true
+      required: [error]
+      description: Respuesta de error devuelta por los controladores API.
+    SuccessResponse:
+      type: object
+      properties:
+        ok:
+          type: string
+        data:
+          type: object
+          additionalProperties: true
+      required: [ok]
+      description: Mensaje genérico de confirmación.
+    GenericModel:
+      type: object
+      additionalProperties: true
+      description: Representación genérica de un modelo expuesto por la API.
+    SchemaField:
+      type: object
+      properties:
+        type:
+          type: string
+        default:
+          nullable: true
+        is_nullable:
+          type: boolean
+      required: [type, default, is_nullable]
+    Cliente:
+      type: object
+      properties:
+        codcliente:
+          type: string
+          description: Código único (hasta 10 caracteres).
+        nombre:
+          type: string
+        razonsocial:
+          type: string
+        cifnif:
+          type: string
+        email:
+          type: string
+          format: email
+        telefono1:
+          type: string
+        telefono2:
+          type: string
+        debaja:
+          type: boolean
+        observaciones:
+          type: string
+        fechaalta:
+          type: string
+          format: date
+      additionalProperties: true
+    Producto:
+      type: object
+      properties:
+        idproducto:
+          type: integer
+        referencia:
+          type: string
+        descripcion:
+          type: string
+        precio:
+          type: number
+          format: float
+        tipo:
+          type: string
+        secompra:
+          type: boolean
+        sevende:
+          type: boolean
+        stockfis:
+          type: number
+          format: float
+        publico:
+          type: boolean
+        bloqueado:
+          type: boolean
+        observaciones:
+          type: string
+      additionalProperties: true
+    AttachedFile:
+      type: object
+      properties:
+        idfile:
+          type: integer
+        filename:
+          type: string
+        path:
+          type: string
+        mimetype:
+          type: string
+        size:
+          type: integer
+          format: int64
+        date:
+          type: string
+          format: date
+        hour:
+          type: string
+          format: time
+        download:
+          type: string
+          format: uri
+        download-permanent:
+          type: string
+          format: uri
+      additionalProperties: true
+    ProductoImagen:
+      type: object
+      properties:
+        id:
+          type: integer
+        idproducto:
+          type: integer
+        idfile:
+          type: integer
+        referencia:
+          type: string
+        orden:
+          type: integer
+        download:
+          type: string
+          format: uri
+        download-permanent:
+          type: string
+          format: uri
+      additionalProperties: true
+    Plugin:
+      type: object
+      properties:
+        name:
+          type: string
+        version:
+          type: number
+        description:
+          type: string
+        enabled:
+          type: boolean
+        hidden:
+          type: boolean
+        installed:
+          type: boolean
+        compatible:
+          type: boolean
+        min_version:
+          type: number
+        min_php:
+          type: number
+        require:
+          type: array
+          items:
+            type: string
+      additionalProperties: true
+    DocumentLineInput:
+      type: object
+      properties:
+        referencia:
+          type: string
+          description: Referencia del artículo.
+        descripcion:
+          type: string
+        cantidad:
+          type: number
+          format: float
+          default: 1
+        pvpunitario:
+          type: number
+          format: float
+        dtopor:
+          type: number
+          format: float
+        dtopor2:
+          type: number
+          format: float
+        codimpuesto:
+          type: string
+        excepcioniva:
+          type: string
+        suplido:
+          type: boolean
+        mostrar_cantidad:
+          type: boolean
+        mostrar_precio:
+          type: boolean
+        salto_pagina:
+          type: boolean
+      additionalProperties: true
+    DocumentCreationResponse:
+      type: object
+      properties:
+        doc:
+          type: object
+          additionalProperties: true
+          description: Datos persistidos del documento.
+        lines:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          description: Líneas resultantes tras el cálculo de totales.
+      required: [doc, lines]
+    PaymentRequest:
+      type: object
+      required: [pagada]
+      properties:
+        pagada:
+          type: boolean
+        fechapago:
+          type: string
+          format: date
+        codpago:
+          type: string
+      additionalProperties: false
+    UploadFilesResponse:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttachedFile'
+      required: [files]
+    RefundInvoiceRequest:
+      type: object
+      required:
+        - idfactura
+        - fecha
+      properties:
+        idfactura:
+          type: string
+        fecha:
+          type: string
+          format: date
+        hora:
+          type: string
+        codserie:
+          type: string
+        idestado:
+          type: integer
+        nick:
+          type: string
+        observaciones:
+          type: string
+      additionalProperties: true
+      description: |
+        Se admiten campos dinámicos `refund_{idLinea}` para indicar las cantidades a rectificar
+        por cada línea de la factura original. Si no se envían, se rectifican todas las líneas.
+  requestBodies:
+    GenericFormBody:
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            type: object
+            additionalProperties: true
+      description: Datos del modelo enviados como pares clave-valor.
+    SalesDocumentBody:
+      required: true
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            type: object
+            required:
+              - codcliente
+              - lineas
+            properties:
+              codcliente:
+                type: string
+              codalmacen:
+                type: string
+              fecha:
+                type: string
+                format: date
+              hora:
+                type: string
+              coddivisa:
+                type: string
+              pagada:
+                type: boolean
+              lineas:
+                type: string
+                description: JSON con un array de objetos `DocumentLineInput`.
+                example: |
+                  [
+                    {"referencia": "ART-001", "descripcion": "Servicio consultoría", "cantidad": 1, "pvpunitario": 100}
+                  ]
+            additionalProperties: true
+      description: Parámetros requeridos para crear documentos de venta.
+    PurchaseDocumentBody:
+      required: true
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            type: object
+            required:
+              - codproveedor
+              - lineas
+            properties:
+              codproveedor:
+                type: string
+              codalmacen:
+                type: string
+              fecha:
+                type: string
+                format: date
+              hora:
+                type: string
+              coddivisa:
+                type: string
+              pagada:
+                type: boolean
+              lineas:
+                type: string
+                description: JSON con un array de objetos `DocumentLineInput`.
+            additionalProperties: true
+      description: Parámetros requeridos para crear documentos de compra.
+    AttachedFileBody:
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              file:
+                type: string
+                format: binary
+              files:
+                type: array
+                items:
+                  type: string
+                  format: binary
+              descripcion:
+                type: string
+              idfile:
+                type: integer
+              filename:
+                type: string
+            additionalProperties: true
+      description: Subida de archivos individuales aceptando campos adicionales del modelo `AttachedFile`.
+    ProductoImagenBody:
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              file:
+                type: string
+                format: binary
+              files:
+                type: array
+                items:
+                  type: string
+                  format: binary
+              idproducto:
+                type: integer
+              referencia:
+                type: string
+              orden:
+                type: integer
+            required:
+              - idproducto
+            additionalProperties: true
+      description: Subida de imágenes asociadas a un producto. Se admite un único fichero por petición.
+    UploadFilesBody:
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              files:
+                type: array
+                items:
+                  type: string
+                  format: binary
+            required: [files]
+      description: Carga masiva de ficheros al directorio `MyFiles`.
+    PaymentBody:
+      required: true
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            $ref: '#/components/schemas/PaymentRequest'
+      description: Datos necesarios para marcar o desmarcar una factura como pagada.
+    RefundInvoiceBody:
+      required: true
+      content:
+        application/x-www-form-urlencoded:
+          schema:
+            $ref: '#/components/schemas/RefundInvoiceRequest'
+      description: Datos obligatorios y opcionales para generar una factura rectificativa.
+  responses:
+    UnauthorizedError:
+      description: Token de autenticación ausente o inválido.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: authentication-required
+    BadRequestError:
+      description: Petición mal formada o sin los parámetros obligatorios.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: invalid-request
+    ConflictError:
+      description: Conflicto por duplicidad o imposibilidad de completar la operación solicitada.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: duplicate-record
+    UnprocessableEntityError:
+      description: El modelo no ha podido guardarse porque las validaciones han fallado.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: record-save-error
+    ServerError:
+      description: Error inesperado al procesar la solicitud en el servidor.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: internal-server-error
+    ForbiddenError:
+      description: El token proporcionado no dispone de permisos suficientes.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            error: access-denied
+    NotFoundError:
+      description: Recurso o registro no encontrado.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+paths:
+  /api/3:
+    get:
+      tags: [Descubrimiento]
+      summary: Listar recursos disponibles
+      description: Devuelve los nombres de todos los controladores y modelos expuestos por la API.
+      responses:
+        '200':
+          description: Recursos disponibles.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  resources:
+                    type: array
+                    items:
+                      type: string
+              example:
+                resources: ["clientes", "productos", "crearFacturaCliente", "attachedfiles"]
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /api/3/{resource}:
+    parameters:
+      - $ref: '#/components/parameters/ResourceParam'
+    get:
+      tags: [Recursos genéricos]
+      summary: Listar registros de un recurso
+      description: |
+        Recupera colecciones de cualquier modelo disponible. Incluye paginación mediante `limit` y `offset`,
+        filtros dinámicos y ordenación. La cabecera `X-Total-Count` informa del total de coincidencias.
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - $ref: '#/components/parameters/FilterParam'
+        - $ref: '#/components/parameters/SortParam'
+        - $ref: '#/components/parameters/OperationParam'
+      responses:
+        '200':
+          description: Colección de registros.
+          headers:
+            X-Total-Count:
+              $ref: '#/components/headers/TotalCount'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GenericModel'
+              example:
+                - codcliente: C0001
+                  nombre: Cliente API
+                  debaja: false
+                - codcliente: C0002
+                  nombre: Cliente Demo
+                  debaja: false
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+    post:
+      tags: [Recursos genéricos]
+      summary: Crear un nuevo registro
+      description: Inserta un registro del modelo asociado. El campo clave primaria no debe existir previamente.
+      requestBody:
+        $ref: '#/components/requestBodies/GenericFormBody'
+      responses:
+        '200':
+          description: Registro creado correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+  /api/3/{resource}/schema:
+    parameters:
+      - $ref: '#/components/parameters/ResourceParam'
+    get:
+      tags: [Recursos genéricos]
+      summary: Obtener metadatos de un modelo
+      description: Devuelve el tipo de datos, valor por defecto y nulabilidad de cada campo del modelo solicitado.
+      responses:
+        '200':
+          description: Esquema del modelo.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/SchemaField'
+              example:
+                codcliente:
+                  type: string
+                  default: null
+                  is_nullable: false
+                nombre:
+                  type: string
+                  default: ''
+                  is_nullable: false
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /api/3/{resource}/{recordId}:
+    parameters:
+      - $ref: '#/components/parameters/ResourceParam'
+      - $ref: '#/components/parameters/RecordIdParam'
+    get:
+      tags: [Recursos genéricos]
+      summary: Consultar un registro por su identificador
+      responses:
+        '200':
+          description: Registro encontrado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericModel'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+    put:
+      tags: [Recursos genéricos]
+      summary: Actualizar un registro existente
+      requestBody:
+        $ref: '#/components/requestBodies/GenericFormBody'
+      responses:
+        '200':
+          description: Registro actualizado correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+    delete:
+      tags: [Recursos genéricos]
+      summary: Eliminar un registro
+      responses:
+        '200':
+          description: Eliminación confirmada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  /api/3/attachedfiles:
+    get:
+      tags: [Archivos]
+      summary: Listar archivos adjuntos
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - $ref: '#/components/parameters/FilterParam'
+        - $ref: '#/components/parameters/SortParam'
+        - $ref: '#/components/parameters/OperationParam'
+      responses:
+        '200':
+          description: Relación de adjuntos registrados, incluyendo enlaces temporales y permanentes de descarga.
+          headers:
+            X-Total-Count:
+              $ref: '#/components/headers/TotalCount'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AttachedFile'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+    post:
+      tags: [Archivos]
+      summary: Subir o registrar un archivo adjunto
+      description: Acepta multipart/form-data con uno o varios campos de archivo. Los ficheros `.php` se descartan por seguridad.
+      requestBody:
+        $ref: '#/components/requestBodies/AttachedFileBody'
+      responses:
+        '200':
+          description: Registro creado o actualizado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityError'
+  /api/3/attachedfiles/schema:
+    get:
+      tags: [Archivos]
+      summary: Obtener el esquema del modelo AttachedFile
+      responses:
+        '200':
+          description: Metadatos de campos del modelo AttachedFile.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/SchemaField'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /api/3/attachedfiles/{idfile}:
+    parameters:
+      - $ref: '#/components/parameters/AttachedFileIdParam'
+    get:
+      tags: [Archivos]
+      summary: Obtener los metadatos de un adjunto
+      responses:
+        '200':
+          description: Información del adjunto solicitada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachedFile'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    put:
+      tags: [Archivos]
+      summary: Actualizar los campos de un adjunto
+      requestBody:
+        $ref: '#/components/requestBodies/GenericFormBody'
+      responses:
+        '200':
+          description: Actualización realizada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    delete:
+      tags: [Archivos]
+      summary: Eliminar un adjunto y su fichero físico
+      responses:
+        '200':
+          description: Adjuntos eliminado correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+  /api/3/uploadFiles:
+    post:
+      tags: [Archivos]
+      summary: Subir varios ficheros en lote
+      requestBody:
+        $ref: '#/components/requestBodies/UploadFilesBody'
+      responses:
+        '200':
+          description: Resultado de la carga masiva.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadFilesResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+    put:
+      tags: [Archivos]
+      summary: Subir varios ficheros en lote (método alternativo)
+      requestBody:
+        $ref: '#/components/requestBodies/UploadFilesBody'
+      responses:
+        '200':
+          description: Resultado de la carga masiva.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UploadFilesResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /api/3/productoimagenes:
+    get:
+      tags: [Archivos]
+      summary: Listar imágenes vinculadas a productos
+      parameters:
+        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - $ref: '#/components/parameters/FilterParam'
+        - $ref: '#/components/parameters/SortParam'
+        - $ref: '#/components/parameters/OperationParam'
+      responses:
+        '200':
+          description: Imágenes asociadas a productos, incluyendo enlaces de descarga.
+          headers:
+            X-Total-Count:
+              $ref: '#/components/headers/TotalCount'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductoImagen'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+    post:
+      tags: [Archivos]
+      summary: Subir una imagen para un producto
+      requestBody:
+        $ref: '#/components/requestBodies/ProductoImagenBody'
+      responses:
+        '200':
+          description: Imagen vinculada correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityError'
+  /api/3/productoimagenes/schema:
+    get:
+      tags: [Archivos]
+      summary: Obtener el esquema del modelo ProductoImagen
+      responses:
+        '200':
+          description: Metadatos de campos del modelo ProductoImagen.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/SchemaField'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /api/3/productoimagenes/{imagenId}:
+    parameters:
+      - $ref: '#/components/parameters/ProductoImagenIdParam'
+    get:
+      tags: [Archivos]
+      summary: Obtener una imagen asociada a producto
+      responses:
+        '200':
+          description: Datos de la imagen solicitada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductoImagen'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+    put:
+      tags: [Archivos]
+      summary: Actualizar los metadatos de una imagen
+      requestBody:
+        $ref: '#/components/requestBodies/GenericFormBody'
+      responses:
+        '200':
+          description: Imagen actualizada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityError'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    delete:
+      tags: [Archivos]
+      summary: Eliminar una imagen de producto
+      responses:
+        '200':
+          description: Imagen eliminada correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+  /api/3/plugins:
+    get:
+      tags: [Plugins]
+      summary: Listar plugins disponibles
+      parameters:
+        - $ref: '#/components/parameters/FilterParam'
+        - $ref: '#/components/parameters/SortParam'
+      responses:
+        '200':
+          description: Catálogo de plugins instalados o disponibles.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Plugin'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /api/3/crearAlbaranCliente:
+    post: &SalesDocumentOperation
+      tags: [Documentos]
+      summary: Crear albarán de cliente
+      description: Genera un documento de venta asignando el cliente y las líneas proporcionadas.
+      requestBody:
+        $ref: '#/components/requestBodies/SalesDocumentBody'
+      responses:
+        '200':
+          description: Documento creado correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentCreationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityError'
+    put:
+      <<: *SalesDocumentOperation
+      summary: Reintentar creación de albarán de cliente
+  /api/3/crearFacturaCliente:
+    post:
+      <<: *SalesDocumentOperation
+      summary: Crear factura de cliente
+    put:
+      <<: *SalesDocumentOperation
+      summary: Reintentar creación de factura de cliente
+  /api/3/crearPedidoCliente:
+    post:
+      <<: *SalesDocumentOperation
+      summary: Crear pedido de cliente
+    put:
+      <<: *SalesDocumentOperation
+      summary: Reintentar creación de pedido de cliente
+  /api/3/crearPresupuestoCliente:
+    post:
+      <<: *SalesDocumentOperation
+      summary: Crear presupuesto de cliente
+    put:
+      <<: *SalesDocumentOperation
+      summary: Reintentar creación de presupuesto de cliente
+  /api/3/crearAlbaranProveedor:
+    post: &PurchaseDocumentOperation
+      tags: [Documentos]
+      summary: Crear albarán de proveedor
+      description: Genera un documento de compra vinculado al proveedor indicado.
+      requestBody:
+        $ref: '#/components/requestBodies/PurchaseDocumentBody'
+      responses:
+        '200':
+          description: Documento creado correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentCreationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityError'
+    put:
+      <<: *PurchaseDocumentOperation
+      summary: Reintentar creación de albarán de proveedor
+  /api/3/crearFacturaProveedor:
+    post:
+      <<: *PurchaseDocumentOperation
+      summary: Crear factura de proveedor
+    put:
+      <<: *PurchaseDocumentOperation
+      summary: Reintentar creación de factura de proveedor
+  /api/3/crearPedidoProveedor:
+    post:
+      <<: *PurchaseDocumentOperation
+      summary: Crear pedido de proveedor
+    put:
+      <<: *PurchaseDocumentOperation
+      summary: Reintentar creación de pedido de proveedor
+  /api/3/crearPresupuestoProveedor:
+    post:
+      <<: *PurchaseDocumentOperation
+      summary: Crear presupuesto de proveedor
+    put:
+      <<: *PurchaseDocumentOperation
+      summary: Reintentar creación de presupuesto de proveedor
+  /api/3/crearFacturaRectificativaCliente:
+    post:
+      tags: [Documentos]
+      summary: Generar factura rectificativa de cliente
+      description: Crea una rectificativa a partir de una factura existente. Permite indicar cantidades a rectificar por línea mediante campos `refund_{id}`.
+      requestBody:
+        $ref: '#/components/requestBodies/RefundInvoiceBody'
+      responses:
+        '200':
+          description: Factura rectificativa creada correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentCreationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+    put:
+      tags: [Documentos]
+      summary: Reintentar creación de factura rectificativa de cliente
+      requestBody:
+        $ref: '#/components/requestBodies/RefundInvoiceBody'
+      responses:
+        '200':
+          description: Factura rectificativa creada correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentCreationResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  /api/3/pagarFacturaCliente/{facturaId}:
+    parameters:
+      - $ref: '#/components/parameters/PaymentInvoiceIdParam'
+    post:
+      tags: [Pagos]
+      summary: Marcar factura de cliente como cobrada o pendiente
+      requestBody:
+        $ref: '#/components/requestBodies/PaymentBody'
+      responses:
+        '200':
+          description: Estado de la factura actualizado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+    put:
+      tags: [Pagos]
+      summary: Marcar factura de cliente como cobrada o pendiente (método alternativo)
+      requestBody:
+        $ref: '#/components/requestBodies/PaymentBody'
+      responses:
+        '200':
+          description: Estado de la factura actualizado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  /api/3/pagarFacturaProveedor/{facturaId}:
+    parameters:
+      - $ref: '#/components/parameters/PaymentInvoiceIdParam'
+    post:
+      tags: [Pagos]
+      summary: Marcar factura de proveedor como pagada o pendiente
+      requestBody:
+        $ref: '#/components/requestBodies/PaymentBody'
+      responses:
+        '200':
+          description: Estado de la factura actualizado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+    put:
+      tags: [Pagos]
+      summary: Marcar factura de proveedor como pagada o pendiente (método alternativo)
+      requestBody:
+        $ref: '#/components/requestBodies/PaymentBody'
+      responses:
+        '200':
+          description: Estado de la factura actualizado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  /api/3/exportarAlbaranCliente/{documentId}:
+    parameters:
+      - $ref: '#/components/parameters/ExportRecordParam'
+    get: &ExportOperation
+      tags: [Exportaciones]
+      summary: Exportar documento en formato imprimible
+      parameters:
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum: [PDF, XLS, CSV, MAIL]
+          description: Formato de salida soportado por `ExportManager`.
+        - name: format
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+          description: Identificador de formato personalizado (`FormatoDocumento`).
+        - name: lang
+          in: query
+          schema:
+            type: string
+          description: Código de idioma a emplear en la exportación.
+      responses:
+        '200':
+          description: Documento generado.
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binary
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+  /api/3/exportarAlbaranProveedor/{documentId}:
+    parameters:
+      - $ref: '#/components/parameters/ExportRecordParam'
+    get:
+      <<: *ExportOperation
+      summary: Exportar albarán de proveedor
+  /api/3/exportarFacturaCliente/{documentId}:
+    parameters:
+      - $ref: '#/components/parameters/ExportRecordParam'
+    get:
+      <<: *ExportOperation
+      summary: Exportar factura de cliente
+  /api/3/exportarFacturaProveedor/{documentId}:
+    parameters:
+      - $ref: '#/components/parameters/ExportRecordParam'
+    get:
+      <<: *ExportOperation
+      summary: Exportar factura de proveedor
+  /api/3/exportarPedidoCliente/{documentId}:
+    parameters:
+      - $ref: '#/components/parameters/ExportRecordParam'
+    get:
+      <<: *ExportOperation
+      summary: Exportar pedido de cliente
+  /api/3/exportarPedidoProveedor/{documentId}:
+    parameters:
+      - $ref: '#/components/parameters/ExportRecordParam'
+    get:
+      <<: *ExportOperation
+      summary: Exportar pedido de proveedor
+  /api/3/exportarPresupuestoCliente/{documentId}:
+    parameters:
+      - $ref: '#/components/parameters/ExportRecordParam'
+    get:
+      <<: *ExportOperation
+      summary: Exportar presupuesto de cliente
+  /api/3/exportarPresupuestoProveedor/{documentId}:
+    parameters:
+      - $ref: '#/components/parameters/ExportRecordParam'
+    get:
+      <<: *ExportOperation
+      summary: Exportar presupuesto de proveedor

--- a/docs/postman/FacturaScripts-2025-API.postman_collection.json
+++ b/docs/postman/FacturaScripts-2025-API.postman_collection.json
@@ -1,0 +1,909 @@
+{
+  "info": {
+    "_postman_id": "f0c1b2b4-8c82-4e19-81e9-9a60c5ff0001",
+    "name": "FacturaScripts 2025 API",
+    "description": "Colección de endpoints REST para la API v3 de FacturaScripts 2025. Incluye ejemplos de uso con encabezados de autenticación por token, filtros, paginación y operaciones especializadas como la creación de documentos o la gestión de archivos.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "apikey",
+    "apikey": [
+      {
+        "key": "value",
+        "value": "{{api_token}}",
+        "type": "string"
+      },
+      {
+        "key": "key",
+        "value": "X-Auth-Token",
+        "type": "string"
+      },
+      {
+        "key": "in",
+        "value": "header",
+        "type": "string"
+      }
+    ]
+  },
+  "item": [
+    {
+      "name": "Introducción y autenticación",
+      "description": "Puntos de partida para descubrir los recursos disponibles y validar que el token configurado concede acceso a la API REST.",
+      "item": [
+        {
+          "name": "Ver recursos expuestos",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3"
+              ]
+            },
+            "description": "Devuelve la lista de recursos disponibles (modelos y endpoints especializados). Basado en el controlador ApiRoot, que expone los recursos registrados en el núcleo y en los plugins."
+          },
+          "response": []
+        },
+        {
+          "name": "Obtener esquema de clientes",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/clientes/schema",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "clientes",
+                "schema"
+              ]
+            },
+            "description": "Recupera el esquema del modelo Cliente (tipos de campo, valores por defecto y si admiten nulos). Útil para preparar cargas de datos antes de crear o actualizar clientes."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Clientes",
+      "description": "Operaciones CRUD estándar sobre el recurso clientes. El modelo aplica validaciones como la obligatoriedad del nombre y el control de duplicados por código.",
+      "item": [
+        {
+          "name": "Listar clientes (paginación y filtros)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/clientes?limit=25&offset=0&filter[debaja]=0&sort[nombre]=ASC",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "clientes"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "25"
+                },
+                {
+                  "key": "offset",
+                  "value": "0"
+                },
+                {
+                  "key": "filter[debaja]",
+                  "value": "0"
+                },
+                {
+                  "key": "sort[nombre]",
+                  "value": "ASC"
+                }
+              ]
+            },
+            "description": "Listado paginado de clientes activos. Se utilizan los parámetros \"filter\", \"sort\", \"limit\" y \"offset\" que procesa el recurso APIModel para generar las cláusulas WHERE y ORDER BY correspondientes."
+          },
+          "response": []
+        },
+        {
+          "name": "Crear cliente",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "codcliente",
+                  "value": "{{cliente_codigo}}",
+                  "description": "Código único del cliente (alfanumérico hasta 10 caracteres)."
+                },
+                {
+                  "key": "nombre",
+                  "value": "Cliente API",
+                  "description": "Nombre comercial obligatorio del cliente."
+                },
+                {
+                  "key": "razonsocial",
+                  "value": "Cliente API",
+                  "description": "Razón social. Si se omite, el modelo copia el nombre."
+                },
+                {
+                  "key": "cifnif",
+                  "value": "B12345678",
+                  "description": "Identificador fiscal del cliente."
+                },
+                {
+                  "key": "email",
+                  "value": "cliente@example.com",
+                  "description": "Correo electrónico principal."
+                },
+                {
+                  "key": "telefono1",
+                  "value": "+34 911223344",
+                  "description": "Teléfono de contacto."
+                },
+                {
+                  "key": "observaciones",
+                  "value": "Creado desde Postman",
+                  "description": "Texto libre de observaciones."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/clientes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "clientes"
+              ]
+            },
+            "description": "Crea un nuevo cliente. El endpoint valida que el código no exista previamente y que los campos obligatorios (como nombre) estén informados."
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar cliente",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "codcliente",
+                  "value": "{{cliente_codigo}}",
+                  "description": "Código del cliente a actualizar."
+                },
+                {
+                  "key": "nombre",
+                  "value": "Cliente API actualizado",
+                  "description": "Nuevo nombre visible."
+                },
+                {
+                  "key": "telefono1",
+                  "value": "+34 911223355",
+                  "description": "Ejemplo de cambio de teléfono."
+                },
+                {
+                  "key": "observaciones",
+                  "value": "Datos revisados desde la API",
+                  "description": "Notas internas tras la actualización."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/clientes/{{cliente_codigo}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "clientes",
+                "{{cliente_codigo}}"
+              ]
+            },
+            "description": "Actualiza un cliente existente. Si el código no se encuentra se devuelve un 404; los cambios válidos se guardan y el recurso responde con los datos actualizados."
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar cliente",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/clientes/{{cliente_codigo}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "clientes",
+                "{{cliente_codigo}}"
+              ]
+            },
+            "description": "Elimina el cliente indicado si existe. El recurso devuelve un mensaje de confirmación en caso de borrado correcto."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Productos",
+      "description": "Gestión básica del catálogo de productos, incluyendo creación, actualización y filtrado por referencia.",
+      "item": [
+        {
+          "name": "Listar productos",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/productos?limit=20&sort[referencia]=ASC",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "productos"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "20"
+                },
+                {
+                  "key": "sort[referencia]",
+                  "value": "ASC"
+                }
+              ]
+            },
+            "description": "Obtiene un listado de productos ordenado por referencia. Se pueden añadir filtros adicionales (por ejemplo filter[codfamilia]) siguiendo las reglas del recurso APIModel."
+          },
+          "response": []
+        },
+        {
+          "name": "Crear producto",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "referencia",
+                  "value": "API-001",
+                  "description": "Referencia o SKU del artículo."
+                },
+                {
+                  "key": "descripcion",
+                  "value": "Producto creado desde la API",
+                  "description": "Descripción corta."
+                },
+                {
+                  "key": "precio",
+                  "value": "120",
+                  "description": "Precio base sin impuestos."
+                },
+                {
+                  "key": "codimpuesto",
+                  "value": "IVA21",
+                  "description": "Código de impuesto asociado al producto."
+                },
+                {
+                  "key": "sevende",
+                  "value": "1",
+                  "description": "Marcar en 1 para permitir ventas."
+                },
+                {
+                  "key": "secompra",
+                  "value": "1",
+                  "description": "Marcar en 1 si también se compra a proveedores."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/productos",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "productos"
+              ]
+            },
+            "description": "Da de alta un nuevo producto. El modelo establece valores por defecto como la fecha de alta y permite controlar impuestos mediante el campo codimpuesto."
+          },
+          "response": []
+        },
+        {
+          "name": "Actualizar producto",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "idproducto",
+                  "value": "{{producto_id}}",
+                  "description": "Identificador interno del producto."
+                },
+                {
+                  "key": "descripcion",
+                  "value": "Descripción actualizada desde la API",
+                  "description": "Nuevo texto descriptivo."
+                },
+                {
+                  "key": "precio",
+                  "value": "135",
+                  "description": "Precio actualizado."
+                },
+                {
+                  "key": "publico",
+                  "value": "1",
+                  "description": "Marcar en 1 para indicar que el producto es público/sincronizable."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/productos/{{producto_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "productos",
+                "{{producto_id}}"
+              ]
+            },
+            "description": "Modifica un producto existente. Si el id no corresponde a un registro válido la API responde con 404."
+          },
+          "response": []
+        },
+        {
+          "name": "Eliminar producto",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/productos/{{producto_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "productos",
+                "{{producto_id}}"
+              ]
+            },
+            "description": "Elimina el producto indicado, devolviendo confirmación en caso de éxito."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Documentos de venta",
+      "description": "Endpoints especializados para crear documentos comerciales, exportarlos y gestionar su estado de cobro.",
+      "item": [
+        {
+          "name": "Crear factura de cliente",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "codcliente",
+                  "value": "{{cliente_codigo}}",
+                  "description": "Código del cliente para asignar el sujeto del documento."
+                },
+                {
+                  "key": "codserie",
+                  "value": "A",
+                  "description": "Serie de facturación a utilizar."
+                },
+                {
+                  "key": "codalmacen",
+                  "value": "1",
+                  "description": "Código de almacén desde el que se sirven las líneas."
+                },
+                {
+                  "key": "fecha",
+                  "value": "{{document_date}}",
+                  "description": "Fecha del documento en formato AAAA-MM-DD."
+                },
+                {
+                  "key": "hora",
+                  "value": "10:00",
+                  "description": "Hora opcional del documento (HH:MM)."
+                },
+                {
+                  "key": "observaciones",
+                  "value": "Generada desde Postman",
+                  "description": "Notas que se guardarán en la factura."
+                },
+                {
+                  "key": "lineas",
+                  "value": "[{\"descripcion\":\"Servicio de consultoría\",\"cantidad\":2,\"pvpunitario\":50,\"codimpuesto\":\"IVA21\"}]",
+                  "description": "JSON con el detalle de líneas. Cada línea puede incluir referencia, cantidad, precio, descuentos y códigos de impuestos."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/crearFacturaCliente",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "crearFacturaCliente"
+              ]
+            },
+            "description": "Crea una factura de cliente asignando sujeto, almacén, fecha y líneas. El endpoint valida la existencia del cliente, calcula totales y devuelve el documento junto con las líneas generadas."
+          },
+          "response": []
+        },
+        {
+          "name": "Marcar factura como pagada",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "pagada",
+                  "value": "true",
+                  "description": "Indica si la factura debe marcarse como pagada (true) o pendiente (false)."
+                },
+                {
+                  "key": "fechapago",
+                  "value": "{{document_date}}",
+                  "description": "Fecha de pago para registrar en los recibos."
+                },
+                {
+                  "key": "codpago",
+                  "value": "CONT",
+                  "description": "Código de forma de pago aplicado al cobro."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/pagarFacturaCliente/{{factura_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "pagarFacturaCliente",
+                "{{factura_id}}"
+              ]
+            },
+            "description": "Actualiza el estado de cobro de una factura de cliente. Marca los recibos asociados como pagados o pendientes según el valor de \"pagada\"."
+          },
+          "response": []
+        },
+        {
+          "name": "Exportar factura a PDF",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/exportarFacturaCliente/{{factura_id}}?type=PDF&format=0",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "exportarFacturaCliente",
+                "{{factura_id}}"
+              ],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "PDF"
+                },
+                {
+                  "key": "format",
+                  "value": "0"
+                }
+              ]
+            },
+            "description": "Genera la exportación del documento en PDF (u otros formatos soportados) utilizando el gestor de exportaciones integrado."
+          },
+          "response": []
+        },
+        {
+          "name": "Crear factura rectificativa",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "idfactura",
+                  "value": "{{factura_id}}",
+                  "description": "Identificador de la factura original que se rectifica."
+                },
+                {
+                  "key": "fecha",
+                  "value": "{{document_date}}",
+                  "description": "Fecha de la factura rectificativa."
+                },
+                {
+                  "key": "hora",
+                  "value": "11:00",
+                  "description": "Hora opcional."
+                },
+                {
+                  "key": "codserie",
+                  "value": "A",
+                  "description": "Serie a emplear en la rectificativa."
+                },
+                {
+                  "key": "observaciones",
+                  "value": "Rectificación parcial desde API",
+                  "description": "Notas internas."
+                },
+                {
+                  "key": "refund_{{factura_linea_id}}",
+                  "value": "1",
+                  "description": "Cantidad a rectificar para una línea concreta (usar el id de línea real). Si no se incluyen cantidades se rectifican todas las líneas."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/crearFacturaRectificativaCliente",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "crearFacturaRectificativaCliente"
+              ]
+            },
+            "description": "Genera una factura rectificativa a partir de otra existente. Permite indicar qué líneas se abonan y ajusta los totales automáticamente."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Archivos y multimedia",
+      "description": "Gestión de ficheros adjuntos genéricos y recursos multimedia asociados a productos.",
+      "item": [
+        {
+          "name": "Listar archivos adjuntos",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/attachedfiles?limit=20",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "attachedfiles"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "20"
+                }
+              ]
+            },
+            "description": "Devuelve los archivos adjuntos registrados, incluyendo URLs temporales y permanentes para su descarga."
+          },
+          "response": []
+        },
+        {
+          "name": "Subir archivo adjunto",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": "/ruta/al/archivo.pdf",
+                  "description": "Archivo a subir. Los ficheros .php son ignorados por seguridad."
+                },
+                {
+                  "key": "descripcion",
+                  "value": "Documento adjunto subido desde Postman",
+                  "description": "Descripción opcional almacenada junto al adjunto."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/attachedfiles",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "attachedfiles"
+              ]
+            },
+            "description": "Carga un nuevo archivo en la carpeta MyFiles y crea el registro asociado."
+          },
+          "response": []
+        },
+        {
+          "name": "Descargar archivo adjunto",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/attachedfiles/{{attachedfile_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "attachedfiles",
+                "{{attachedfile_id}}"
+              ]
+            },
+            "description": "Recupera los metadatos del archivo y proporciona enlaces de descarga."
+          },
+          "response": []
+        },
+        {
+          "name": "Subida múltiple (uploadFiles)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "files",
+                  "type": "file",
+                  "src": "/ruta/a/imagen1.png",
+                  "description": "Primer archivo a subir en lote."
+                },
+                {
+                  "key": "files",
+                  "type": "file",
+                  "src": "/ruta/a/imagen2.png",
+                  "description": "Segundo archivo del lote."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/uploadFiles",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "uploadFiles"
+              ]
+            },
+            "description": "Permite subir varios archivos en una sola petición. El servicio ignora ficheros inválidos o con extensión PHP y devuelve la lista de adjuntos creados."
+          },
+          "response": []
+        },
+        {
+          "name": "Listar imágenes de producto",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/productoimagenes?filter[idproducto]={{producto_id}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "productoimagenes"
+              ],
+              "query": [
+                {
+                  "key": "filter[idproducto]",
+                  "value": "{{producto_id}}"
+                }
+              ]
+            },
+            "description": "Lista las imágenes asociadas a un producto concreto, incluyendo URLs directas de descarga."
+          },
+          "response": []
+        },
+        {
+          "name": "Subir imagen de producto",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "multipart/form-data"
+              }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "idproducto",
+                  "value": "{{producto_id}}",
+                  "description": "Producto al que se vincula la imagen."
+                },
+                {
+                  "key": "descripcion",
+                  "value": "Imagen principal subida desde API",
+                  "description": "Texto descriptivo de la imagen."
+                },
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": "/ruta/a/imagen.png",
+                  "description": "Archivo de imagen a almacenar."
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{base_url}}/api/3/productoimagenes",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "productoimagenes"
+              ]
+            },
+            "description": "Sube una imagen y crea el registro correspondiente. El servicio devuelve confirmación y los datos guardados."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Plugins y utilidades",
+      "description": "Consultas auxiliares sobre el estado del sistema y los plugins instalados.",
+      "item": [
+        {
+          "name": "Listar plugins instalados",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/3/plugins",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "3",
+                "plugins"
+              ]
+            },
+            "description": "Devuelve el listado de plugins detectados por el núcleo, permitiendo aplicar filtros y ordenaciones mediante los parámetros estándar de la API."
+          },
+          "response": []
+        }
+      ]
+    }
+  ],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8000",
+      "type": "string"
+    },
+    {
+      "key": "api_token",
+      "value": "changeme",
+      "type": "string"
+    },
+    {
+      "key": "cliente_codigo",
+      "value": "C0001",
+      "type": "string"
+    },
+    {
+      "key": "producto_id",
+      "value": "1",
+      "type": "string"
+    },
+    {
+      "key": "factura_id",
+      "value": "1",
+      "type": "string"
+    },
+    {
+      "key": "factura_linea_id",
+      "value": "1",
+      "type": "string"
+    },
+    {
+      "key": "attachedfile_id",
+      "value": "1",
+      "type": "string"
+    },
+    {
+      "key": "document_date",
+      "value": "2025-01-15",
+      "type": "string"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Postman collection that documents the FacturaScripts 2025 API v3 token header and resource discovery endpoints
- include CRUD examples for core resources such as clientes and productos with form-encoded payloads that match APIModel requirements
- document specialized endpoints for document generation, payments, exports, file uploads, and plugin listings with ready-to-run requests

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d1b9f82b3083289e76b5942517fee6