### PR TITLE
Add plugin to edit product stock by size-color matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /doc/
 /MyFiles/
 /node_modules/
-/Plugins/
+/Plugins/*
+!/Plugins/MatrizTallaColor/
+!/Plugins/MatrizTallaColor/**
 /vendor/
 .DS_Store
 .htaccess

--- a/Plugins/MatrizTallaColor/Controller/EditProducto.php
+++ b/Plugins/MatrizTallaColor/Controller/EditProducto.php
@@ -1,0 +1,345 @@
+<?php
+namespace FacturaScripts\Plugins\MatrizTallaColor\Controller;
+
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Controller\EditProducto as BaseEditProducto;
+use FacturaScripts\Core\Model\Atributo;
+use FacturaScripts\Core\Model\Producto;
+use FacturaScripts\Core\Model\Stock;
+use FacturaScripts\Core\Model\Variante;
+use FacturaScripts\Core\Tools;
+
+class EditProducto extends BaseEditProducto
+{
+    /** @var string */
+    public $matrixAttributeX = '';
+
+    /** @var string */
+    public $matrixAttributeY = '';
+
+    /** @var array<int, array<string, mixed>> */
+    public $matrixValuesX = [];
+
+    /** @var array<int, array<string, mixed>> */
+    public $matrixValuesY = [];
+
+    /** @var array<int, array<int, array<string, mixed>>> */
+    public $matrixGrid = [];
+
+    /** @var string */
+    public $matrixWarehouse = '';
+
+    /** @var bool */
+    public $matrixHasData = false;
+
+    /** @var Variante|null */
+    private $matrixBaseVariant = null;
+
+    protected function createViews()
+    {
+        parent::createViews();
+        $this->createMatrixView();
+    }
+
+    protected function createMatrixView(string $viewName = 'MatrixAttribute'): void
+    {
+        $view = $this->addHtmlView($viewName, 'Tab/MatrixAttribute', 'Producto', 'size-color-matrix', 'fa-solid fa-table');
+        $view->settings['btnDelete'] = false;
+        $view->settings['btnNew'] = false;
+        $view->settings['btnOptions'] = false;
+        $view->settings['btnSave'] = false;
+        $view->settings['btnUndo'] = false;
+    }
+
+    protected function execPreviousAction($action)
+    {
+        switch ($action) {
+            case 'matrix-generate':
+                return $this->handleMatrixGenerate();
+
+            case 'matrix-save':
+                return $this->handleMatrixSave();
+        }
+
+        return parent::execPreviousAction($action);
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    public function getMatrixAttributes(): array
+    {
+        $attribute = new Atributo();
+        $attributes = [];
+        foreach ($attribute->all([], ['nombre' => 'ASC'], 0, 0) as $item) {
+            $attributes[] = [
+                'code' => $item->codatributo,
+                'name' => $item->nombre,
+                'selector' => (int)$item->num_selector,
+            ];
+        }
+
+        return $attributes;
+    }
+
+    private function handleMatrixGenerate(): bool
+    {
+        $this->active = 'MatrixAttribute';
+        $attributeX = Tools::noHtml($this->request->inputOrQuery('matrix_attribute_x', ''));
+        $attributeY = Tools::noHtml($this->request->inputOrQuery('matrix_attribute_y', ''));
+        $warehouse = Tools::noHtml($this->request->inputOrQuery('matrix_codalmacen', ''));
+
+        return $this->prepareMatrix($attributeX, $attributeY, $warehouse);
+    }
+
+    private function handleMatrixSave(): bool
+    {
+        $this->active = 'MatrixAttribute';
+        $attributeX = Tools::noHtml($this->request->inputOrQuery('matrix_attribute_x', ''));
+        $attributeY = Tools::noHtml($this->request->inputOrQuery('matrix_attribute_y', ''));
+        $warehouse = Tools::noHtml($this->request->inputOrQuery('matrix_codalmacen', ''));
+
+        if (false === $this->prepareMatrix($attributeX, $attributeY, $warehouse)) {
+            return false;
+        }
+
+        $stocks = $this->request->request->getArray('matrix_stock', true) ?? [];
+        foreach ($this->matrixValuesY as $row) {
+            $idY = (int)$row['id'];
+            $rowStocks = $stocks[$idY] ?? [];
+            foreach ($this->matrixValuesX as $column) {
+                $idX = (int)$column['id'];
+                $value = $rowStocks[$idX] ?? '';
+                $quantity = max(0.0, (float)str_replace(',', '.', (string)$value));
+                $this->updateVariantStock($idX, $idY, $quantity);
+            }
+        }
+
+        Tools::log()->notice('matrix-stock-updated');
+        return true;
+    }
+
+    private function prepareMatrix(string $attributeX, string $attributeY, string $warehouse): bool
+    {
+        $this->matrixAttributeX = $attributeX;
+        $this->matrixAttributeY = $attributeY;
+        $this->matrixWarehouse = empty($warehouse) ? Tools::settings('default', 'codalmacen') : $warehouse;
+        $this->matrixHasData = false;
+        $this->matrixValuesX = [];
+        $this->matrixValuesY = [];
+        $this->matrixGrid = [];
+        $this->matrixBaseVariant = null;
+
+        if (empty($attributeX) || empty($attributeY)) {
+            Tools::log()->warning('matrix-select-two-attributes');
+            return false;
+        }
+        if ($attributeX === $attributeY) {
+            Tools::log()->warning('matrix-attributes-must-differ');
+            return false;
+        }
+
+        $product = $this->loadMatrixProduct();
+        if (null === $product) {
+            return false;
+        }
+
+        $axisX = $this->loadAttribute($attributeX);
+        $axisY = $this->loadAttribute($attributeY);
+        if (null === $axisX || null === $axisY) {
+            return false;
+        }
+
+        $fieldX = $this->getVariantFieldForAttribute($axisX);
+        $fieldY = $this->getVariantFieldForAttribute($axisY);
+        if (empty($fieldX) || empty($fieldY)) {
+            return false;
+        }
+
+        $this->matrixValuesX = $this->getAttributeValues($axisX);
+        $this->matrixValuesY = $this->getAttributeValues($axisY);
+
+        if (empty($this->matrixValuesX) || empty($this->matrixValuesY)) {
+            Tools::log()->warning('matrix-attributes-need-values');
+            return false;
+        }
+
+        foreach ($this->matrixValuesY as $row) {
+            $rowId = (int)$row['id'];
+            $this->matrixGrid[$rowId] = [];
+            foreach ($this->matrixValuesX as $column) {
+                $colId = (int)$column['id'];
+                $variant = $this->ensureVariantExists($product, [
+                    $fieldX => $colId,
+                    $fieldY => $rowId,
+                ]);
+
+                if (null === $variant) {
+                    continue;
+                }
+
+                $stock = $this->loadVariantStock($variant, $this->matrixWarehouse);
+                $this->matrixGrid[$rowId][$colId] = [
+                    'variant' => $variant,
+                    'stock' => $stock,
+                ];
+            }
+        }
+
+        $this->matrixHasData = true;
+        return true;
+    }
+
+    private function loadMatrixProduct(): ?Producto
+    {
+        $idProduct = $this->request->inputOrQuery('idproducto', '');
+        $product = $this->getModel();
+        if (!empty($idProduct) && (!$product->exists() || (string)$product->idproducto !== (string)$idProduct)) {
+            $product->loadFromCode($idProduct);
+        }
+
+        if (false === $product->exists()) {
+            Tools::log()->warning('record-not-found');
+            return null;
+        }
+
+        return $product;
+    }
+
+    private function loadAttribute(string $code): ?Atributo
+    {
+        $attribute = new Atributo();
+        if (false === $attribute->load($code)) {
+            Tools::log()->warning('matrix-attribute-not-found', ['%code%' => $code]);
+            return null;
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * @param Atributo $attribute
+     * @return array<int, array<string, mixed>>
+     */
+    private function getAttributeValues(Atributo $attribute): array
+    {
+        $values = [];
+        foreach ($attribute->getValues() as $value) {
+            $values[] = [
+                'id' => (int)$value->id,
+                'label' => $value->valor,
+            ];
+        }
+
+        return $values;
+    }
+
+    private function getVariantFieldForAttribute(Atributo $attribute): string
+    {
+        $selector = (int)$attribute->num_selector;
+        if ($selector < 1 || $selector > 4) {
+            Tools::log()->warning('matrix-selector-required', ['%attribute%' => $attribute->nombre]);
+            return '';
+        }
+
+        return 'idatributovalor' . $selector;
+    }
+
+    /**
+     * @param Producto $product
+     * @param array<string, int> $values
+     */
+    private function ensureVariantExists(Producto $product, array $values): ?Variante
+    {
+        $variant = new Variante();
+        $where = [new DataBaseWhere('idproducto', $product->idproducto)];
+        foreach ($values as $field => $valueId) {
+            $where[] = new DataBaseWhere($field, $valueId);
+        }
+
+        if (true === $variant->loadWhere($where)) {
+            return $variant;
+        }
+
+        $variant->idproducto = $product->idproducto;
+        foreach ($values as $field => $valueId) {
+            $variant->{$field} = $valueId;
+        }
+
+        $baseVariant = $this->getBaseVariant($product);
+        if (null !== $baseVariant) {
+            $variant->precio = $baseVariant->precio;
+            $variant->coste = $baseVariant->coste;
+        }
+        $variant->referencia = '';
+
+        if (false === $variant->save()) {
+            Tools::log()->error('matrix-variant-create-error');
+            return null;
+        }
+
+        return $variant;
+    }
+
+    private function loadVariantStock(Variante $variant, string $warehouse): float
+    {
+        $stock = new Stock();
+        $where = [
+            new DataBaseWhere('referencia', $variant->referencia),
+            new DataBaseWhere('codalmacen', $warehouse),
+        ];
+
+        if (true === $stock->loadWhere($where)) {
+            return (float)$stock->cantidad;
+        }
+
+        return 0.0;
+    }
+
+    private function updateVariantStock(int $valueX, int $valueY, float $quantity): void
+    {
+        if (false === isset($this->matrixGrid[$valueY][$valueX])) {
+            return;
+        }
+
+        /** @var Variante $variant */
+        $variant = $this->matrixGrid[$valueY][$valueX]['variant'];
+        $stock = new Stock();
+        $where = [
+            new DataBaseWhere('referencia', $variant->referencia),
+            new DataBaseWhere('codalmacen', $this->matrixWarehouse),
+        ];
+
+        if (true === $stock->loadWhere($where)) {
+            $stock->cantidad = $quantity;
+        } else {
+            $stock->codalmacen = $this->matrixWarehouse;
+            $stock->idproducto = $variant->idproducto;
+            $stock->referencia = $variant->referencia;
+            $stock->cantidad = $quantity;
+        }
+
+        $stock->save();
+        $this->matrixGrid[$valueY][$valueX]['stock'] = $quantity;
+    }
+
+    private function getBaseVariant(Producto $product): ?Variante
+    {
+        if ($this->matrixBaseVariant instanceof Variante) {
+            return $this->matrixBaseVariant;
+        }
+
+        $variant = new Variante();
+        $where = [
+            new DataBaseWhere('idproducto', $product->idproducto),
+            new DataBaseWhere('referencia', $product->referencia),
+        ];
+
+        if (true === $variant->loadWhere($where)) {
+            $this->matrixBaseVariant = $variant;
+            return $this->matrixBaseVariant;
+        }
+
+        return null;
+    }
+}

--- a/Plugins/MatrizTallaColor/Translation/en_US.json
+++ b/Plugins/MatrizTallaColor/Translation/en_US.json
@@ -1,0 +1,17 @@
+{
+    "matrix-attribute-x": "Attribute X",
+    "matrix-attribute-y": "Attribute Y",
+    "matrix-generate": "Generate",
+    "matrix-save": "Save matrix",
+    "matrix-select-help": "Select two attributes and click Generate to display the stock matrix.",
+    "matrix-stock-header": "Stock for warehouse %warehouse%",
+    "matrix-row-header": "Values",
+    "matrix-variant-error": "Variant could not be created",
+    "matrix-select-two-attributes": "You must select two attributes to build the matrix.",
+    "matrix-attributes-must-differ": "X and Y attributes must be different.",
+    "matrix-attribute-not-found": "Attribute %code% was not found.",
+    "matrix-selector-required": "Attribute %attribute% must have an assigned selector (1-4).",
+    "matrix-attributes-need-values": "Selected attributes must contain values.",
+    "matrix-variant-create-error": "One of the required variants could not be created.",
+    "matrix-stock-updated": "Matrix stock updated successfully."
+}

--- a/Plugins/MatrizTallaColor/Translation/es_ES.json
+++ b/Plugins/MatrizTallaColor/Translation/es_ES.json
@@ -1,0 +1,17 @@
+{
+    "matrix-attribute-x": "Atributo X",
+    "matrix-attribute-y": "Atributo Y",
+    "matrix-generate": "Generar",
+    "matrix-save": "Guardar matriz",
+    "matrix-select-help": "Selecciona dos atributos y pulsa Generar para ver la matriz de stock.",
+    "matrix-stock-header": "Stock para el almacén %warehouse%",
+    "matrix-row-header": "Valores",
+    "matrix-variant-error": "No se pudo crear la variante",
+    "matrix-select-two-attributes": "Debes seleccionar dos atributos para generar la matriz.",
+    "matrix-attributes-must-differ": "Los atributos X e Y deben ser distintos.",
+    "matrix-attribute-not-found": "No se encontró el atributo %code%.",
+    "matrix-selector-required": "El atributo %attribute% debe tener asignado un selector (1-4).",
+    "matrix-attributes-need-values": "Los atributos seleccionados deben tener valores definidos.",
+    "matrix-variant-create-error": "No se ha podido crear una de las variantes necesarias.",
+    "matrix-stock-updated": "Stock de la matriz actualizado correctamente."
+}

--- a/Plugins/MatrizTallaColor/View/Tab/MatrixAttribute.html.twig
+++ b/Plugins/MatrizTallaColor/View/Tab/MatrixAttribute.html.twig
@@ -1,0 +1,113 @@
+{% set firstView = fsc.views | first %}
+{% set product = firstView.model %}
+{% set attributes = fsc.getMatrixAttributes() %}
+{% set currentView = fsc.getCurrentView() %}
+
+<div class="container-fluid">
+    <div class="row mb-3">
+        <div class="col">
+            <form action="{{ product.url() }}" method="post" class="row g-3 align-items-end">
+                {{ formToken() }}
+                <input type="hidden" name="action" value="matrix-generate" />
+                <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}" />
+                <input type="hidden" name="idproducto" value="{{ product.primaryColumnValue() }}" />
+                <div class="col-md-4">
+                    <label class="form-label" for="matrix_attribute_x">{{ trans('matrix-attribute-x') }}</label>
+                    <select id="matrix_attribute_x" name="matrix_attribute_x" class="form-select" required>
+                        <option value="">--</option>
+                        {% for attribute in attributes %}
+                            {% set selected = attribute.code == fsc.matrixAttributeX ? 'selected' : '' %}
+                            <option value="{{ attribute.code }}" {{ selected }}>
+                                {{ attribute.name }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label" for="matrix_attribute_y">{{ trans('matrix-attribute-y') }}</label>
+                    <select id="matrix_attribute_y" name="matrix_attribute_y" class="form-select" required>
+                        <option value="">--</option>
+                        {% for attribute in attributes %}
+                            {% set selected = attribute.code == fsc.matrixAttributeY ? 'selected' : '' %}
+                            <option value="{{ attribute.code }}" {{ selected }}>
+                                {{ attribute.name }}
+                            </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label" for="matrix_codalmacen">{{ trans('warehouse') }}</label>
+                    <input type="text" id="matrix_codalmacen" name="matrix_codalmacen" value="{{ fsc.matrixWarehouse }}"
+                           class="form-control" maxlength="10" />
+                </div>
+                <div class="col-md-1 d-grid">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa-solid fa-table"></i>
+                        {{ trans('matrix-generate') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    {% if fsc.matrixHasData %}
+        <div class="row">
+            <div class="col">
+                <form action="{{ product.url() }}" method="post" class="card shadow-sm">
+                    {{ formToken() }}
+                    <input type="hidden" name="action" value="matrix-save" />
+                    <input type="hidden" name="activetab" value="{{ currentView.getViewName() }}" />
+                    <input type="hidden" name="idproducto" value="{{ product.primaryColumnValue() }}" />
+                    <input type="hidden" name="matrix_attribute_x" value="{{ fsc.matrixAttributeX }}" />
+                    <input type="hidden" name="matrix_attribute_y" value="{{ fsc.matrixAttributeY }}" />
+                    <input type="hidden" name="matrix_codalmacen" value="{{ fsc.matrixWarehouse }}" />
+                    <div class="card-header bg-light">
+                        <strong>{{ trans('matrix-stock-header', {'%warehouse%': fsc.matrixWarehouse}) }}</strong>
+                    </div>
+                    <div class="card-body p-0 table-responsive">
+                        <table class="table table-bordered table-sm align-middle mb-0">
+                            <thead class="table-light">
+                                <tr>
+                                    <th scope="col">{{ trans('matrix-row-header') }}</th>
+                                    {% for column in fsc.matrixValuesX %}
+                                        <th scope="col" class="text-center">{{ column.label }}</th>
+                                    {% endfor %}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in fsc.matrixValuesY %}
+                                    <tr>
+                                        <th scope="row">{{ row.label }}</th>
+                                        {% for column in fsc.matrixValuesX %}
+                                            {% set cell = fsc.matrixGrid[row.id][column.id] ?? null %}
+                                            <td>
+                                                {% if cell %}
+                                                    <div class="small text-muted mb-1">{{ cell.variant.referencia }}</div>
+                                                    <input type="number" class="form-control form-control-sm"
+                                                           name="matrix_stock[{{ row.id }}][{{ column.id }}]"
+                                                           value="{{ cell.stock }}" step="0.001" min="0" />
+                                                {% else %}
+                                                    <span class="text-muted">{{ trans('matrix-variant-error') }}</span>
+                                                {% endif %}
+                                            </td>
+                                        {% endfor %}
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="card-footer text-end">
+                        <button type="submit" class="btn btn-success">
+                            <i class="fa-solid fa-save"></i>
+                            {{ trans('matrix-save') }}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    {% else %}
+        <div class="alert alert-info">
+            {{ trans('matrix-select-help') }}
+        </div>
+    {% endif %}
+</div>

--- a/Plugins/MatrizTallaColor/facturascripts.ini
+++ b/Plugins/MatrizTallaColor/facturascripts.ini
@@ -1,0 +1,5 @@
+name = MatrizTallaColor
+version = 1.0
+min_version = 2025.0
+description = "Gestiona stock por matriz de atributos (talla x color)"
+require = ""


### PR DESCRIPTION
## Summary
- add the MatrizTallaColor plugin that extends EditProducto with a two-attribute matrix, automatically generating missing variants and persisting stock updates
- provide the matrix tab UI plus Spanish and English translations for the new strings
- relax the gitignore entry so the new plugin folder is tracked in the repository

## Testing
- php -l Plugins/MatrizTallaColor/Controller/EditProducto.php

------
https://chatgpt.com/codex/tasks/task_e_68dd65765d4c83289ddb1b7fb17c7c9b