### PR TITLE
Add webhooks plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /doc/
 /MyFiles/
 /node_modules/
-/Plugins/
+/Plugins/*
+!/Plugins/Webhooks/
+!/Plugins/Webhooks/**
 /vendor/
 .DS_Store
 .htaccess

--- a/Plugins/Webhooks/Controller/EditWebhookRule.php
+++ b/Plugins/Webhooks/Controller/EditWebhookRule.php
@@ -1,0 +1,21 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Controller;
+
+use FacturaScripts\Core\Lib\ExtendedController\EditController;
+
+class EditWebhookRule extends EditController
+{
+    public function getModelClassName(): string
+    {
+        return 'WebhookRule';
+    }
+
+    public function getPageData(): array
+    {
+        $data = parent::getPageData();
+        $data['title'] = 'webhook-rule';
+        $data['menu'] = 'admin';
+        $data['icon'] = 'fa-solid fa-plug';
+        return $data;
+    }
+}

--- a/Plugins/Webhooks/Controller/ListWebhookRule.php
+++ b/Plugins/Webhooks/Controller/ListWebhookRule.php
@@ -1,0 +1,33 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Controller;
+
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Lib\ExtendedController\ListController;
+
+class ListWebhookRule extends ListController
+{
+    public function getPageData(): array
+    {
+        $data = parent::getPageData();
+        $data['title'] = 'webhook-rules';
+        $data['menu'] = 'admin';
+        $data['icon'] = 'fa-solid fa-plug';
+        $data['showonmenu'] = true;
+        return $data;
+    }
+
+    protected function createViews(): void
+    {
+        $this->createWebhookRuleView();
+    }
+
+    protected function createWebhookRuleView(string $viewName = 'ListWebhookRule'): void
+    {
+        $this->addView($viewName, 'WebhookRule', 'webhook-rules', 'fa-solid fa-plug')
+            ->addSearchFields(['model', 'endpoint', 'description'])
+            ->addOrderBy(['model', 'endpoint'], 'model')
+            ->addOrderBy(['active', 'model'], 'status');
+
+        $this->addFilterCheckbox($viewName, 'only_active', 'status', 'active', '=', true, [new DataBaseWhere('active', true)]);
+    }
+}

--- a/Plugins/Webhooks/Extension/Model/Base/ModelClass.php
+++ b/Plugins/Webhooks/Extension/Model/Base/ModelClass.php
@@ -1,0 +1,22 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Extension\Model\Base;
+
+use Closure;
+use FacturaScripts\Plugins\Webhooks\Lib\WebhookDispatcher;
+
+class ModelClass
+{
+    protected function onInsert(): Closure
+    {
+        return function (): void {
+            WebhookDispatcher::dispatch($this, 'insert');
+        };
+    }
+
+    protected function onUpdate(): Closure
+    {
+        return function (): void {
+            WebhookDispatcher::dispatch($this, 'update');
+        };
+    }
+}

--- a/Plugins/Webhooks/Init.php
+++ b/Plugins/Webhooks/Init.php
@@ -1,0 +1,24 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks;
+
+use FacturaScripts\Core\DbUpdater;
+use FacturaScripts\Core\Template\InitClass;
+
+class Init extends InitClass
+{
+    public function init(): void
+    {
+        $this->loadExtension(new Extension\Model\Base\ModelClass());
+    }
+
+    public function uninstall(): void
+    {
+        DbUpdater::dropTable('webhook_rules');
+    }
+
+    public function update(): void
+    {
+        new Model\WebhookRule();
+        $this->updateTableData('webhook_rules');
+    }
+}

--- a/Plugins/Webhooks/Lib/WebhookDispatcher.php
+++ b/Plugins/Webhooks/Lib/WebhookDispatcher.php
@@ -1,0 +1,61 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Lib;
+
+use FacturaScripts\Core\Http;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Template\ModelClass as BaseModelClass;
+use FacturaScripts\Plugins\Webhooks\Model\WebhookRule;
+
+class WebhookDispatcher
+{
+    public static function dispatch(BaseModelClass $model, string $event): void
+    {
+        $rules = WebhookRule::activeForModel($model->modelClassName(), $event);
+        if (empty($rules)) {
+            return;
+        }
+
+        foreach ($rules as $rule) {
+            if (false === $rule->shouldTrigger($model)) {
+                continue;
+            }
+
+            $payload = self::buildPayload($model, $event);
+            $request = Http::postJson($rule->endpoint, $payload);
+            $request->ok();
+
+            if ($request->failed()) {
+                Tools::log()->warning('webhook-request-failed', [
+                    '%endpoint%' => $rule->endpoint,
+                    '%error%' => $request->errorMessage(),
+                ]);
+            }
+        }
+    }
+
+    protected static function buildPayload(BaseModelClass $model, string $event): array
+    {
+        $data = $model->toArray();
+        $payload = [
+            'event' => $event,
+            'model' => $model->modelClassName(),
+            'data' => $data,
+        ];
+
+        if (method_exists($model, 'getLines')) {
+            $lines = [];
+            foreach ($model->getLines() as $line) {
+                if (method_exists($line, 'toArray')) {
+                    $lines[] = $line->toArray();
+                }
+            }
+
+            $payload['data'] = [
+                'header' => $data,
+                'lines' => $lines,
+            ];
+        }
+
+        return $payload;
+    }
+}

--- a/Plugins/Webhooks/Model/WebhookRule.php
+++ b/Plugins/Webhooks/Model/WebhookRule.php
@@ -1,0 +1,162 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Model;
+
+use FacturaScripts\Core\Template\ModelClass as BaseModelClass;
+use FacturaScripts\Core\Template\ModelTrait;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
+
+class WebhookRule extends BaseModelClass
+{
+    use ModelTrait;
+
+    public $idwebhookrule;
+    public $model;
+    public $endpoint;
+    public $description;
+    public $condition_text;
+    public $active;
+    public $on_insert;
+    public $on_update;
+
+    public function clear(): void
+    {
+        parent::clear();
+        $this->active = true;
+        $this->on_insert = true;
+        $this->on_update = true;
+    }
+
+    public static function primaryColumn(): string
+    {
+        return 'idwebhookrule';
+    }
+
+    public static function tableName(): string
+    {
+        return 'webhook_rules';
+    }
+
+    public static function activeForModel(string $modelName, string $event): array
+    {
+        $where = [
+            Where::eq('active', true),
+            Where::eq('model', $modelName),
+        ];
+
+        if ('insert' === $event) {
+            $where[] = Where::eq('on_insert', true);
+        } elseif ('update' === $event) {
+            $where[] = Where::eq('on_update', true);
+        }
+
+        return self::all($where, ['idwebhookrule' => 'ASC']);
+    }
+
+    public function install(): string
+    {
+        return parent::install();
+    }
+
+    public function shouldTrigger(BaseModelClass $model): bool
+    {
+        foreach ($this->parseConditions() as $condition) {
+            $currentValue = $model->{$condition['field']} ?? null;
+            $expected = $condition['value'];
+            $operator = $condition['operator'];
+
+            if (false === $this->compareValues($currentValue, $expected, $operator)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function parseConditions(): array
+    {
+        $conditions = [];
+        $raw = trim((string)$this->condition_text);
+        if ($raw === '') {
+            return $conditions;
+        }
+
+        $parts = preg_split('/[\r\n;]+/', $raw);
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if ($part === '') {
+                continue;
+            }
+
+            if (!preg_match('/^(?P<field>[a-zA-Z0-9_]+)\s*(?P<operator>>=|<=|!=|=|>|<)\s*(?P<value>.+)$/', $part, $matches)) {
+                Tools::log()->warning('invalid-webhook-condition', ['%condition%' => $part]);
+                continue;
+            }
+
+            $conditions[] = [
+                'field' => $matches['field'],
+                'operator' => $matches['operator'],
+                'value' => $this->normalizeValue($matches['value']),
+            ];
+        }
+
+        return $conditions;
+    }
+
+    protected function normalizeValue(string $value)
+    {
+        $value = trim($value);
+        if ((str_starts_with($value, '"') && str_ends_with($value, '"'))
+            || (str_starts_with($value, "'") && str_ends_with($value, "'"))) {
+            return substr($value, 1, -1);
+        }
+
+        if (is_numeric($value)) {
+            return $value + 0;
+        }
+
+        $lower = strtolower($value);
+        if (in_array($lower, ['true', 'false'], true)) {
+            return $lower === 'true';
+        }
+
+        if ($lower === 'null') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    protected function compareValues($currentValue, $expected, string $operator): bool
+    {
+        switch ($operator) {
+            case '=':
+                return $this->normalizeComparison($currentValue) == $expected;
+            case '!=':
+                return $this->normalizeComparison($currentValue) != $expected;
+            case '>':
+                return $this->normalizeComparison($currentValue) > $expected;
+            case '<':
+                return $this->normalizeComparison($currentValue) < $expected;
+            case '>=':
+                return $this->normalizeComparison($currentValue) >= $expected;
+            case '<=':
+                return $this->normalizeComparison($currentValue) <= $expected;
+        }
+
+        return true;
+    }
+
+    protected function normalizeComparison($value)
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return $value + 0;
+        }
+
+        return null === $value ? null : trim((string)$value);
+    }
+}

--- a/Plugins/Webhooks/README.md
+++ b/Plugins/Webhooks/README.md
@@ -1,0 +1,38 @@
+# Webhooks
+
+Este plugin añade una pantalla de configuración (ListWebhookRule) desde la que se pueden definir reglas para lanzar peticiones **POST** a endpoints externos cuando se crean o modifican registros en FacturaScripts.
+
+## Características
+
+- Activación independiente por modelo y por evento (insert/update).
+- Condiciones de disparo basadas en comparaciones sencillas (por ejemplo `codserie = X; estado = 3`).
+- Envío de todo el contenido del modelo como JSON. En documentos de venta/compra el JSON incluye los datos de cabecera y las líneas del documento.
+
+## Formato de las condiciones
+
+Cada regla puede incluir varias condiciones separadas por saltos de línea o punto y coma. Cada condición admite los operadores `=`, `!=`, `<`, `<=`, `>` y `>=`. Los valores pueden ir entre comillas para conservar espacios o distinguir mayúsculas/minúsculas.
+
+## Payload enviado
+
+```json
+{
+  "event": "insert|update",
+  "model": "NombreDelModelo",
+  "data": {
+    "campo": "valor"
+  }
+}
+```
+
+En el caso de documentos (`getLines()` disponible), la clave `data` incluye:
+
+```json
+{
+  "header": { "..." },
+  "lines": [ { "..." } ]
+}
+```
+
+## Desinstalación
+
+Al desinstalar el plugin se elimina la tabla `webhook_rules`.

--- a/Plugins/Webhooks/Table/webhook_rules.xml
+++ b/Plugins/Webhooks/Table/webhook_rules.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table>
+    <column>
+        <name>idwebhookrule</name>
+        <type>serial</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>model</name>
+        <type>character varying(100)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>endpoint</name>
+        <type>character varying(255)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>description</name>
+        <type>character varying(150)</type>
+        <null>YES</null>
+    </column>
+    <column>
+        <name>condition_text</name>
+        <type>text</type>
+        <null>YES</null>
+    </column>
+    <column>
+        <name>active</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>true</default>
+    </column>
+    <column>
+        <name>on_insert</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>true</default>
+    </column>
+    <column>
+        <name>on_update</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>true</default>
+    </column>
+    <constraint>
+        <name>webhook_rules_pkey</name>
+        <type>PRIMARY KEY (idwebhookrule)</type>
+    </constraint>
+    <index>
+        <name>webhook_rules_model_idx</name>
+        <fields>model</fields>
+    </index>
+</table>

--- a/Plugins/Webhooks/Translation/es_ES.json
+++ b/Plugins/Webhooks/Translation/es_ES.json
@@ -1,0 +1,12 @@
+{
+    "webhook-rules": "Webhooks",
+    "webhook-rule": "Regla de webhook",
+    "invalid-webhook-condition": "Condición de webhook no válida: %condition%",
+    "webhook-request-failed": "No se pudo enviar el webhook a %endpoint%: %error%",
+    "condition-text": "Condición",
+    "condition_text": "Condición",
+    "on-insert": "Al crear",
+    "on-update": "Al actualizar",
+    "on_insert": "Al crear",
+    "on_update": "Al actualizar"
+}

--- a/Plugins/Webhooks/XMLView/WebhookRule.xml
+++ b/Plugins/Webhooks/XMLView/WebhookRule.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<view>
+    <columns>
+        <column name="description" order="10">
+            <widget type="text" fieldname="description" placeholder="Descripción" />
+        </column>
+        <column name="model" order="20">
+            <widget type="text" fieldname="model" placeholder="Modelo (por ejemplo, FacturaCliente)" />
+        </column>
+        <column name="endpoint" order="30">
+            <widget type="text" fieldname="endpoint" placeholder="https://..." />
+        </column>
+        <column name="active" order="40">
+            <widget type="checkbox" fieldname="active" />
+        </column>
+        <column name="on_insert" order="50">
+            <widget type="checkbox" fieldname="on_insert" />
+        </column>
+        <column name="on_update" order="60">
+            <widget type="checkbox" fieldname="on_update" />
+        </column>
+        <column name="condition_text" order="70">
+            <widget type="textarea" fieldname="condition_text" rows="2" placeholder="serie = X; estado = 3" />
+        </column>
+    </columns>
+</view>

--- a/Plugins/Webhooks/facturascripts.ini
+++ b/Plugins/Webhooks/facturascripts.ini
@@ -1,0 +1,4 @@
+name = 'Webhooks'
+description = 'Dispara webhooks cuando se guardan modelos.'
+version = 1
+min_version = 2024


### PR DESCRIPTION
## Summary
- create a Webhooks plugin that listens to model insert and update events and posts JSON payloads to configured endpoints
- add a WebhookRule model, database schema and admin UI to manage endpoints, activation flags and conditional filters
- document usage and expose translations for the new configuration screen

## Testing
- `find Plugins/Webhooks -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68e820ccf3388328af6e49019fdb212f