### PR TITLE
Add previous-state checks and user context to webhook payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /doc/
 /MyFiles/
 /node_modules/
-/Plugins/
+/Plugins/*
+!/Plugins/Webhooks/
+!/Plugins/Webhooks/**
 /vendor/
 .DS_Store
 .htaccess

--- a/Plugins/Webhooks/Controller/EditWebhookRule.php
+++ b/Plugins/Webhooks/Controller/EditWebhookRule.php
@@ -1,0 +1,44 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Controller;
+
+use FacturaScripts\Core\Lib\ExtendedController\EditController;
+use FacturaScripts\Plugins\Webhooks\Lib\ModelInspector;
+
+class EditWebhookRule extends EditController
+{
+    public function getModelClassName(): string
+    {
+        return 'WebhookRule';
+    }
+
+    public function getPageData(): array
+    {
+        $data = parent::getPageData();
+        $data['title'] = 'webhook-rule';
+        $data['menu'] = 'admin';
+        $data['icon'] = 'fa-solid fa-plug';
+        return $data;
+    }
+
+    protected function createViews()
+    {
+        parent::createViews();
+
+        $view = $this->views[$this->getMainViewName()] ?? null;
+        if (null === $view) {
+            return;
+        }
+
+        $column = $view->columnForField('model');
+        if (null === $column || false === method_exists($column->widget, 'setValuesFromArrayKeys')) {
+            return;
+        }
+
+        $options = [];
+        foreach (ModelInspector::extendableModels() as $shortName => $className) {
+            $options[$shortName] = $shortName;
+        }
+
+        $column->widget->setValuesFromArrayKeys($options, false, false);
+    }
+}

--- a/Plugins/Webhooks/Controller/EditWebhookRule.php
+++ b/Plugins/Webhooks/Controller/EditWebhookRule.php
@@ -2,6 +2,7 @@
 namespace FacturaScripts\Plugins\Webhooks\Controller;
 
 use FacturaScripts\Core\Lib\ExtendedController\EditController;
+use FacturaScripts\Core\Tools;
 use FacturaScripts\Plugins\Webhooks\Lib\ModelInspector;
 
 class EditWebhookRule extends EditController
@@ -40,5 +41,71 @@ class EditWebhookRule extends EditController
         }
 
         $column->widget->setValuesFromArrayKeys($options, false, false);
+    }
+
+    protected function execPreviousAction($action)
+    {
+        if ('copy' === $action) {
+            return $this->copyAction();
+        }
+
+        return parent::execPreviousAction($action);
+    }
+
+    protected function loadData($viewName, $view)
+    {
+        parent::loadData($viewName, $view);
+
+        if ($viewName !== $this->getMainViewName() || false === $view->model->exists()) {
+            return;
+        }
+
+        $this->addButton($viewName, [
+            'action' => 'copy',
+            'color' => 'info',
+            'icon' => 'fa-solid fa-copy',
+            'label' => 'clone',
+            'title' => 'clone',
+        ]);
+    }
+
+    private function copyAction(): bool
+    {
+        if (false === $this->permissions->allowUpdate) {
+            Tools::log()->warning('not-allowed-modify');
+            return false;
+        }
+
+        if (false === $this->validateFormToken()) {
+            return false;
+        }
+
+        $mainView = $this->getMainViewName();
+        $view = $this->views[$mainView] ?? null;
+        if (null === $view) {
+            return false;
+        }
+
+        $primaryKey = $view->model->primaryColumn();
+        $code = $this->request->input($primaryKey, '');
+        if (false === $view->model->loadFromCode($code)) {
+            Tools::log()->error('record-not-found');
+            return false;
+        }
+
+        $modelClass = get_class($view->model);
+        $data = $view->model->toArray();
+        unset($data[$primaryKey]);
+
+        $copy = new $modelClass();
+        $copy->loadFromData($data);
+
+        if (false === $copy->save()) {
+            Tools::log()->error('record-save-error');
+            return false;
+        }
+
+        $this->redirect($copy->url() . '&action=save-ok');
+        return false;
     }
 }

--- a/Plugins/Webhooks/Controller/ListWebhookRule.php
+++ b/Plugins/Webhooks/Controller/ListWebhookRule.php
@@ -1,0 +1,33 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Controller;
+
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Lib\ExtendedController\ListController;
+
+class ListWebhookRule extends ListController
+{
+    public function getPageData(): array
+    {
+        $data = parent::getPageData();
+        $data['title'] = 'webhook-rules';
+        $data['menu'] = 'admin';
+        $data['icon'] = 'fa-solid fa-plug';
+        $data['showonmenu'] = true;
+        return $data;
+    }
+
+    protected function createViews(): void
+    {
+        $this->createWebhookRuleView();
+    }
+
+    protected function createWebhookRuleView(string $viewName = 'ListWebhookRule'): void
+    {
+        $this->addView($viewName, 'WebhookRule', 'webhook-rules', 'fa-solid fa-plug')
+            ->addSearchFields(['model', 'endpoint', 'description'])
+            ->addOrderBy(['model', 'endpoint'], 'model')
+            ->addOrderBy(['active', 'model'], 'status');
+
+        $this->addFilterCheckbox($viewName, 'only_active', 'status', 'active', '=', true, [new DataBaseWhere('active', true)]);
+    }
+}

--- a/Plugins/Webhooks/Extension/Controller/Lib/ExtendedController/ListController.php
+++ b/Plugins/Webhooks/Extension/Controller/Lib/ExtendedController/ListController.php
@@ -1,0 +1,72 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Extension\Controller\Lib\ExtendedController;
+
+use Closure;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Plugins\Webhooks\Lib\WebhookDispatcher;
+use FacturaScripts\Plugins\Webhooks\Model\WebhookRule;
+
+class ListController
+{
+    protected function execPreviousAction(): Closure
+    {
+        return function ($action) {
+            if ('webhook-action' !== $action) {
+                return null;
+            }
+
+            if (false === $this->permissions->allowUpdate) {
+                Tools::log()->warning('not-allowed-modify');
+                return false;
+            }
+
+            if (false === $this->validateFormToken()) {
+                return false;
+            }
+
+            $view = $this->views[$this->active] ?? null;
+            if (null === $view || null === $view->model) {
+                return false;
+            }
+
+            $codes = $this->request->request->getArray('codes');
+            if (empty($codes)) {
+                Tools::log()->warning('webhook-no-codes');
+                return false;
+            }
+
+            WebhookDispatcher::dispatchActionForCodes($view->model->modelClassName(), $codes, get_class($view->model));
+            return false;
+        };
+    }
+
+    protected function loadData(): Closure
+    {
+        return function ($viewName, $view): void {
+            if ($viewName !== $this->getMainViewName()) {
+                return;
+            }
+
+            if (isset($this->webhookActionButtons[$viewName])) {
+                return;
+            }
+
+            if (null === $view->model) {
+                return;
+            }
+
+            if (empty(WebhookRule::activeForModel($view->model->modelClassName(), 'action'))) {
+                return;
+            }
+
+            $this->webhookActionButtons[$viewName] = true;
+            $this->addButton($viewName, [
+                'action' => 'webhook-action',
+                'color' => 'warning',
+                'icon' => 'fa-solid fa-bolt',
+                'label' => 'webhook-action',
+                'title' => 'webhook-action',
+            ]);
+        };
+    }
+}

--- a/Plugins/Webhooks/Extension/Controller/Lib/ExtendedController/PanelController.php
+++ b/Plugins/Webhooks/Extension/Controller/Lib/ExtendedController/PanelController.php
@@ -1,0 +1,71 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Extension\Controller\Lib\ExtendedController;
+
+use Closure;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Plugins\Webhooks\Lib\WebhookDispatcher;
+use FacturaScripts\Plugins\Webhooks\Model\WebhookRule;
+
+class PanelController
+{
+    protected function execPreviousAction(): Closure
+    {
+        return function ($action) {
+            if ('webhook-action' !== $action) {
+                return null;
+            }
+
+            if (false === $this->permissions->allowUpdate) {
+                Tools::log()->warning('not-allowed-modify');
+                return false;
+            }
+
+            if (false === $this->validateFormToken()) {
+                return false;
+            }
+
+            $view = $this->views[$this->getMainViewName()] ?? null;
+            if (null === $view || null === $view->model) {
+                return false;
+            }
+
+            if (false === $view->model->exists()) {
+                Tools::log()->warning('record-not-found');
+                return false;
+            }
+
+            WebhookDispatcher::dispatch($view->model, 'action', $view->model->getOriginal());
+            return false;
+        };
+    }
+
+    protected function loadData(): Closure
+    {
+        return function ($viewName, $view): void {
+            if ($viewName !== $this->getMainViewName()) {
+                return;
+            }
+
+            if (isset($this->webhookActionButtons[$viewName])) {
+                return;
+            }
+
+            if (null === $view->model) {
+                return;
+            }
+
+            if (empty(WebhookRule::activeForModel($view->model->modelClassName(), 'action'))) {
+                return;
+            }
+
+            $this->webhookActionButtons[$viewName] = true;
+            $this->addButton($viewName, [
+                'action' => 'webhook-action',
+                'color' => 'warning',
+                'icon' => 'fa-solid fa-bolt',
+                'label' => 'webhook-action',
+                'title' => 'webhook-action',
+            ]);
+        };
+    }
+}

--- a/Plugins/Webhooks/Extension/Model/Base/ModelClass.php
+++ b/Plugins/Webhooks/Extension/Model/Base/ModelClass.php
@@ -1,0 +1,22 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Extension\Model\Base;
+
+use Closure;
+use FacturaScripts\Plugins\Webhooks\Lib\WebhookDispatcher;
+
+class ModelClass
+{
+    protected function onInsert(): Closure
+    {
+        return function (): void {
+            WebhookDispatcher::dispatch($this, 'insert', $this->getOriginal());
+        };
+    }
+
+    protected function onUpdate(): Closure
+    {
+        return function (): void {
+            WebhookDispatcher::dispatch($this, 'update', $this->getOriginal());
+        };
+    }
+}

--- a/Plugins/Webhooks/Init.php
+++ b/Plugins/Webhooks/Init.php
@@ -1,0 +1,28 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks;
+
+use FacturaScripts\Core\DbUpdater;
+use FacturaScripts\Core\Template\InitClass;
+use FacturaScripts\Plugins\Webhooks\Lib\ModelInspector;
+
+class Init extends InitClass
+{
+    public function init(): void
+    {
+        $extension = new Extension\Model\Base\ModelClass();
+        foreach (ModelInspector::extendableModels() as $className) {
+            $className::addExtension($extension);
+        }
+    }
+
+    public function uninstall(): void
+    {
+        DbUpdater::dropTable('webhook_rules');
+    }
+
+    public function update(): void
+    {
+        new Model\WebhookRule();
+        $this->updateTableData('webhook_rules');
+    }
+}

--- a/Plugins/Webhooks/Init.php
+++ b/Plugins/Webhooks/Init.php
@@ -2,6 +2,8 @@
 namespace FacturaScripts\Plugins\Webhooks;
 
 use FacturaScripts\Core\DbUpdater;
+use FacturaScripts\Core\Lib\ExtendedController\ListController as BaseListController;
+use FacturaScripts\Core\Lib\ExtendedController\PanelController as BasePanelController;
 use FacturaScripts\Core\Template\InitClass;
 use FacturaScripts\Plugins\Webhooks\Lib\ModelInspector;
 
@@ -13,6 +15,9 @@ class Init extends InitClass
         foreach (ModelInspector::extendableModels() as $className) {
             $className::addExtension($extension);
         }
+
+        BasePanelController::addExtension(new Extension\Controller\Lib\ExtendedController\PanelController());
+        BaseListController::addExtension(new Extension\Controller\Lib\ExtendedController\ListController());
     }
 
     public function uninstall(): void

--- a/Plugins/Webhooks/Lib/ModelInspector.php
+++ b/Plugins/Webhooks/Lib/ModelInspector.php
@@ -1,0 +1,61 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Lib;
+
+use FacturaScripts\Core\Template\ModelClass as TemplateModelClass;
+use FacturaScripts\Core\Tools;
+use ReflectionClass;
+
+class ModelInspector
+{
+    /**
+     * @var array<string, class-string<TemplateModelClass>>|null
+     */
+    private static $extendableModels;
+
+    /**
+     * Returns the map of extendable model short names to their fully qualified class names.
+     *
+     * @return array<string, class-string<TemplateModelClass>>
+     */
+    public static function extendableModels(): array
+    {
+        if (null !== self::$extendableModels) {
+            return self::$extendableModels;
+        }
+
+        $models = [];
+        $files = Tools::folderScan(FS_FOLDER . '/Dinamic/Model/', true);
+        foreach ($files as $item) {
+            if (false === str_ends_with($item, '.php')) {
+                continue;
+            }
+
+            $relativeClass = substr($item, 0, -4);
+            $relativeClass = str_replace(['/', '\\'], '\\', $relativeClass);
+            $className = '\\FacturaScripts\\Dinamic\\Model\\' . $relativeClass;
+            if (!class_exists($className)) {
+                continue;
+            }
+
+            if (!is_subclass_of($className, TemplateModelClass::class)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($className);
+            if ($reflection->isAbstract() || !$reflection->hasMethod('addExtension')) {
+                continue;
+            }
+
+            $method = $reflection->getMethod('addExtension');
+            if ($method->isAbstract() || !$method->isPublic() || !$method->isStatic()) {
+                continue;
+            }
+
+            $models[$reflection->getShortName()] = $className;
+        }
+
+        ksort($models, SORT_NATURAL | SORT_FLAG_CASE);
+        self::$extendableModels = $models;
+        return self::$extendableModels;
+    }
+}

--- a/Plugins/Webhooks/Lib/WebhookDispatcher.php
+++ b/Plugins/Webhooks/Lib/WebhookDispatcher.php
@@ -1,0 +1,73 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Lib;
+
+use FacturaScripts\Core\Http;
+use FacturaScripts\Core\Session;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Template\ModelClass as BaseModelClass;
+use FacturaScripts\Plugins\Webhooks\Model\WebhookRule;
+
+class WebhookDispatcher
+{
+    public static function dispatch(BaseModelClass $model, string $event, array $original = []): void
+    {
+        $rules = WebhookRule::activeForModel($model->modelClassName(), $event);
+        if (empty($rules)) {
+            return;
+        }
+
+        foreach ($rules as $rule) {
+            if (false === $rule->shouldTrigger($model, $original, $event)) {
+                continue;
+            }
+
+            $payload = self::buildPayload($model, $event, $original);
+            $request = Http::postJson($rule->endpoint, $payload);
+            $request->ok();
+
+            if ($request->failed()) {
+                Tools::log()->warning('webhook-request-failed', [
+                    '%endpoint%' => $rule->endpoint,
+                    '%error%' => $request->errorMessage(),
+                ]);
+            }
+        }
+    }
+
+    protected static function buildPayload(BaseModelClass $model, string $event, array $original): array
+    {
+        $data = $model->toArray();
+        $payload = [
+            'event' => $event,
+            'model' => $model->modelClassName(),
+            'data' => $data,
+            'previous' => empty($original) ? null : $original,
+        ];
+
+        $user = Session::user();
+        if (!empty($user->nick)) {
+            $payload['user'] = ['nick' => $user->nick];
+        }
+
+        if (method_exists($model, 'getLines')) {
+            $lines = [];
+            foreach ($model->getLines() as $line) {
+                if (method_exists($line, 'toArray')) {
+                    $lines[] = $line->toArray();
+                }
+            }
+
+            $payload['data'] = [
+                'header' => $data,
+                'lines' => $lines,
+            ];
+
+            $payload['previous'] = empty($original) ? null : [
+                'header' => $original,
+                'lines' => [],
+            ];
+        }
+
+        return $payload;
+    }
+}

--- a/Plugins/Webhooks/Lib/WebhookDispatcher.php
+++ b/Plugins/Webhooks/Lib/WebhookDispatcher.php
@@ -5,6 +5,7 @@ use FacturaScripts\Core\Http;
 use FacturaScripts\Core\Session;
 use FacturaScripts\Core\Tools;
 use FacturaScripts\Core\Template\ModelClass as BaseModelClass;
+use FacturaScripts\Plugins\Webhooks\Lib\ModelInspector;
 use FacturaScripts\Plugins\Webhooks\Model\WebhookRule;
 
 class WebhookDispatcher
@@ -22,15 +23,37 @@ class WebhookDispatcher
             }
 
             $payload = self::buildPayload($model, $event, $original);
-            $request = Http::postJson($rule->endpoint, $payload);
-            $request->ok();
+            self::sendRule($rule, $payload, $model, $original);
+        }
+    }
 
-            if ($request->failed()) {
-                Tools::log()->warning('webhook-request-failed', [
-                    '%endpoint%' => $rule->endpoint,
-                    '%error%' => $request->errorMessage(),
-                ]);
+    public static function dispatchActionForCodes(string $modelName, array $codes, string $modelClass = ''): void
+    {
+        $rules = WebhookRule::activeForModel($modelName, 'action');
+        if (empty($rules)) {
+            return;
+        }
+
+        $codes = array_values(array_unique(array_filter($codes)));
+        if (empty($codes)) {
+            return;
+        }
+
+        $modelClass = $modelClass ?: (ModelInspector::extendableModels()[$modelName] ?? '');
+
+        foreach ($rules as $rule) {
+            $selectedCodes = self::filterCodesForRule($rule, $codes, $modelClass);
+            if (empty($selectedCodes)) {
+                continue;
             }
+
+            $payload = self::withUser([
+                'event' => 'action',
+                'model' => $modelName,
+                'codes' => $selectedCodes,
+            ]);
+
+            self::sendRule($rule, $payload);
         }
     }
 
@@ -44,10 +67,7 @@ class WebhookDispatcher
             'previous' => empty($original) ? null : $original,
         ];
 
-        $user = Session::user();
-        if (!empty($user->nick)) {
-            $payload['user'] = ['nick' => $user->nick];
-        }
+        $payload = self::withUser($payload);
 
         if (method_exists($model, 'getLines')) {
             $lines = [];
@@ -66,6 +86,66 @@ class WebhookDispatcher
                 'header' => $original,
                 'lines' => [],
             ];
+        }
+
+        return $payload;
+    }
+
+    protected static function filterCodesForRule(WebhookRule $rule, array $codes, string $modelClass): array
+    {
+        if (empty($modelClass) || false === class_exists($modelClass)) {
+            return $codes;
+        }
+
+        $selected = [];
+        foreach ($codes as $code) {
+            $model = new $modelClass();
+            if (false === method_exists($model, 'loadFromCode')) {
+                continue;
+            }
+
+            if (false === $model->loadFromCode($code)) {
+                continue;
+            }
+
+            if (false === $rule->shouldTrigger($model, $model->getOriginal(), 'action')) {
+                continue;
+            }
+
+            $selected[] = $code;
+        }
+
+        return $selected;
+    }
+
+    protected static function sendRule(WebhookRule $rule, array $payload, ?BaseModelClass $model = null, array $original = []): void
+    {
+        $request = Http::postJson($rule->endpoint, $payload);
+        $request->ok();
+
+        $responseText = trim($request->body());
+        $logContext = [
+            '%endpoint%' => $rule->endpoint,
+            '%event%' => $payload['event'] ?? 'unknown',
+        ];
+
+        if ($request->failed()) {
+            $logContext['%error%'] = $request->errorMessage();
+            Tools::log()->warning('webhook-request-failed', $logContext);
+            Tools::log('webhooks')->warning('webhook-request-failed', $logContext);
+            return;
+        }
+
+        $message = $responseText ?: Tools::lang()->trans('webhook-dispatched', $logContext);
+        Tools::log()->notice($message);
+        Tools::log('webhooks')->notice('webhook-dispatched', array_merge($logContext, ['%response%' => $responseText]));
+    }
+
+    protected static function withUser(array $payload): array
+    {
+        $user = Session::user();
+        if (!empty($user->nick)) {
+            $payload['user'] = ['nick' => $user->nick];
         }
 
         return $payload;

--- a/Plugins/Webhooks/Model/WebhookRule.php
+++ b/Plugins/Webhooks/Model/WebhookRule.php
@@ -16,6 +16,7 @@ class WebhookRule extends BaseModelClass
     public $description;
     public $condition_text;
     public $previous_condition_text;
+    public $on_action;
     public $active;
     public $on_insert;
     public $on_update;
@@ -26,6 +27,7 @@ class WebhookRule extends BaseModelClass
         $this->active = true;
         $this->on_insert = true;
         $this->on_update = true;
+        $this->on_action = false;
     }
 
     public static function primaryColumn(): string
@@ -49,6 +51,8 @@ class WebhookRule extends BaseModelClass
             $where[] = Where::eq('on_insert', true);
         } elseif ('update' === $event) {
             $where[] = Where::eq('on_update', true);
+        } elseif ('action' === $event) {
+            $where[] = Where::eq('on_action', true);
         }
 
         return self::all($where, ['idwebhookrule' => 'ASC']);

--- a/Plugins/Webhooks/Model/WebhookRule.php
+++ b/Plugins/Webhooks/Model/WebhookRule.php
@@ -1,0 +1,184 @@
+<?php
+namespace FacturaScripts\Plugins\Webhooks\Model;
+
+use FacturaScripts\Core\Template\ModelClass as BaseModelClass;
+use FacturaScripts\Core\Template\ModelTrait;
+use FacturaScripts\Core\Tools;
+use FacturaScripts\Core\Where;
+
+class WebhookRule extends BaseModelClass
+{
+    use ModelTrait;
+
+    public $idwebhookrule;
+    public $model;
+    public $endpoint;
+    public $description;
+    public $condition_text;
+    public $previous_condition_text;
+    public $active;
+    public $on_insert;
+    public $on_update;
+
+    public function clear(): void
+    {
+        parent::clear();
+        $this->active = true;
+        $this->on_insert = true;
+        $this->on_update = true;
+    }
+
+    public static function primaryColumn(): string
+    {
+        return 'idwebhookrule';
+    }
+
+    public static function tableName(): string
+    {
+        return 'webhook_rules';
+    }
+
+    public static function activeForModel(string $modelName, string $event): array
+    {
+        $where = [
+            Where::eq('active', true),
+            Where::eq('model', $modelName),
+        ];
+
+        if ('insert' === $event) {
+            $where[] = Where::eq('on_insert', true);
+        } elseif ('update' === $event) {
+            $where[] = Where::eq('on_update', true);
+        }
+
+        return self::all($where, ['idwebhookrule' => 'ASC']);
+    }
+
+    public function install(): string
+    {
+        return parent::install();
+    }
+
+    public function shouldTrigger(BaseModelClass $model, array $original = [], string $event = ''): bool
+    {
+        $previousConditions = $this->parseConditionsFrom((string)$this->previous_condition_text);
+        if (!empty($previousConditions)) {
+            if ('update' !== $event) {
+                return false;
+            }
+
+            if (empty($original)) {
+                return false;
+            }
+
+            foreach ($previousConditions as $condition) {
+                $previousValue = $original[$condition['field']] ?? null;
+                $expected = $condition['value'];
+                $operator = $condition['operator'];
+
+                if (false === $this->compareValues($previousValue, $expected, $operator)) {
+                    return false;
+                }
+            }
+        }
+
+        foreach ($this->parseConditionsFrom((string)$this->condition_text) as $condition) {
+            $currentValue = $model->{$condition['field']} ?? null;
+            $expected = $condition['value'];
+            $operator = $condition['operator'];
+
+            if (false === $this->compareValues($currentValue, $expected, $operator)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function parseConditionsFrom(string $raw): array
+    {
+        $conditions = [];
+        $raw = trim($raw);
+        if ($raw === '') {
+            return $conditions;
+        }
+
+        $parts = preg_split('/[\r\n;]+/', $raw);
+        foreach ($parts as $part) {
+            $part = trim($part);
+            if ($part === '') {
+                continue;
+            }
+
+            if (!preg_match('/^(?P<field>[a-zA-Z0-9_]+)\s*(?P<operator>>=|<=|!=|=|>|<)\s*(?P<value>.+)$/', $part, $matches)) {
+                Tools::log()->warning('invalid-webhook-condition', ['%condition%' => $part]);
+                continue;
+            }
+
+            $conditions[] = [
+                'field' => $matches['field'],
+                'operator' => $matches['operator'],
+                'value' => $this->normalizeValue($matches['value']),
+            ];
+        }
+
+        return $conditions;
+    }
+
+    protected function normalizeValue(string $value)
+    {
+        $value = trim($value);
+        if ((str_starts_with($value, '"') && str_ends_with($value, '"'))
+            || (str_starts_with($value, "'") && str_ends_with($value, "'"))) {
+            return substr($value, 1, -1);
+        }
+
+        if (is_numeric($value)) {
+            return $value + 0;
+        }
+
+        $lower = strtolower($value);
+        if (in_array($lower, ['true', 'false'], true)) {
+            return $lower === 'true';
+        }
+
+        if ($lower === 'null') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    protected function compareValues($currentValue, $expected, string $operator): bool
+    {
+        switch ($operator) {
+            case '=':
+                return $this->normalizeComparison($currentValue) == $expected;
+            case '!=':
+                return $this->normalizeComparison($currentValue) != $expected;
+            case '>':
+                return $this->normalizeComparison($currentValue) > $expected;
+            case '<':
+                return $this->normalizeComparison($currentValue) < $expected;
+            case '>=':
+                return $this->normalizeComparison($currentValue) >= $expected;
+            case '<=':
+                return $this->normalizeComparison($currentValue) <= $expected;
+        }
+
+        return true;
+    }
+
+    protected function normalizeComparison($value)
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return $value + 0;
+        }
+
+        return null === $value ? null : trim((string)$value);
+    }
+}

--- a/Plugins/Webhooks/README.md
+++ b/Plugins/Webhooks/README.md
@@ -1,0 +1,41 @@
+# Webhooks
+
+Este plugin añade una pantalla de configuración (ListWebhookRule) desde la que se pueden definir reglas para lanzar peticiones **POST** a endpoints externos cuando se crean o modifican registros en FacturaScripts.
+
+## Características
+
+- Activación independiente por modelo y por evento (insert/update).
+- Condiciones de disparo basadas en comparaciones sencillas (por ejemplo `codserie = X; estado = 3`).
+- Condiciones previas opcionales para comprobar el estado anterior en actualizaciones (por ejemplo `estado = 3` para detectar transiciones `3 -> 5`).
+- Envío de todo el contenido del modelo como JSON. En documentos de venta/compra el JSON incluye los datos de cabecera y las líneas del documento.
+
+## Formato de las condiciones
+
+Cada regla puede incluir varias condiciones separadas por saltos de línea o punto y coma. Cada condición admite los operadores `=`, `!=`, `<`, `<=`, `>` y `>=`. Los valores pueden ir entre comillas para conservar espacios o distinguir mayúsculas/minúsculas.
+
+## Payload enviado
+
+```json
+{
+  "event": "insert|update",
+  "model": "NombreDelModelo",
+  "data": {
+    "campo": "valor"
+  }
+}
+```
+
+En el caso de documentos (`getLines()` disponible), la clave `data` incluye:
+
+```json
+{
+  "header": { "..." },
+  "lines": [ { "..." } ]
+}
+```
+
+Además, el payload incorpora la sección `previous` con los valores previos al guardado (cabecera y líneas vacías en documentos) y `user.nick` cuando la sesión activa lo proporciona.
+
+## Desinstalación
+
+Al desinstalar el plugin se elimina la tabla `webhook_rules`.

--- a/Plugins/Webhooks/README.md
+++ b/Plugins/Webhooks/README.md
@@ -8,6 +8,7 @@ Este plugin añade una pantalla de configuración (ListWebhookRule) desde la que
 - Condiciones de disparo basadas en comparaciones sencillas (por ejemplo `codserie = X; estado = 3`).
 - Condiciones previas opcionales para comprobar el estado anterior en actualizaciones (por ejemplo `estado = 3` para detectar transiciones `3 -> 5`).
 - Envío de todo el contenido del modelo como JSON. En documentos de venta/compra el JSON incluye los datos de cabecera y las líneas del documento.
+- Disparo manual mediante botón en los listados y formularios de edición para las reglas marcadas como "Por acción".
 
 ## Formato de las condiciones
 
@@ -35,6 +36,8 @@ En el caso de documentos (`getLines()` disponible), la clave `data` incluye:
 ```
 
 Además, el payload incorpora la sección `previous` con los valores previos al guardado (cabecera y líneas vacías en documentos) y `user.nick` cuando la sesión activa lo proporciona.
+
+Para las reglas con la opción **Por acción** se envía el evento `action` con el modelo y los códigos seleccionados en listados o, en edición, el registro completo.
 
 ## Desinstalación
 

--- a/Plugins/Webhooks/Table/webhook_rules.xml
+++ b/Plugins/Webhooks/Table/webhook_rules.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table>
+    <column>
+        <name>idwebhookrule</name>
+        <type>serial</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>model</name>
+        <type>character varying(100)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>endpoint</name>
+        <type>character varying(255)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>description</name>
+        <type>character varying(150)</type>
+        <null>YES</null>
+    </column>
+    <column>
+        <name>condition_text</name>
+        <type>text</type>
+        <null>YES</null>
+    </column>
+    <column>
+        <name>previous_condition_text</name>
+        <type>text</type>
+        <null>YES</null>
+    </column>
+    <column>
+        <name>active</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>true</default>
+    </column>
+    <column>
+        <name>on_insert</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>true</default>
+    </column>
+    <column>
+        <name>on_update</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>true</default>
+    </column>
+    <constraint>
+        <name>webhook_rules_pkey</name>
+        <type>PRIMARY KEY (idwebhookrule)</type>
+    </constraint>
+    <index>
+        <name>webhook_rules_model_idx</name>
+        <fields>model</fields>
+    </index>
+</table>

--- a/Plugins/Webhooks/Table/webhook_rules.xml
+++ b/Plugins/Webhooks/Table/webhook_rules.xml
@@ -31,6 +31,12 @@
         <null>YES</null>
     </column>
     <column>
+        <name>on_action</name>
+        <type>boolean</type>
+        <null>NO</null>
+        <default>false</default>
+    </column>
+    <column>
         <name>active</name>
         <type>boolean</type>
         <null>NO</null>

--- a/Plugins/Webhooks/Translation/es_ES.json
+++ b/Plugins/Webhooks/Translation/es_ES.json
@@ -1,0 +1,14 @@
+{
+    "webhook-rules": "Webhooks",
+    "webhook-rule": "Regla de webhook",
+    "invalid-webhook-condition": "Condición de webhook no válida: %condition%",
+    "webhook-request-failed": "No se pudo enviar el webhook a %endpoint%: %error%",
+    "condition-text": "Condición",
+    "condition_text": "Condición",
+    "previous_condition_text": "Condición previa",
+    "model": "Modelo",
+    "on-insert": "Al crear",
+    "on-update": "Al actualizar",
+    "on_insert": "Al crear",
+    "on_update": "Al actualizar"
+}

--- a/Plugins/Webhooks/Translation/es_ES.json
+++ b/Plugins/Webhooks/Translation/es_ES.json
@@ -9,6 +9,11 @@
     "model": "Modelo",
     "on-insert": "Al crear",
     "on-update": "Al actualizar",
+    "on-action": "Por acción",
     "on_insert": "Al crear",
-    "on_update": "Al actualizar"
+    "on_update": "Al actualizar",
+    "on_action": "Por acción",
+    "webhook-action": "Enviar webhook",
+    "webhook-dispatched": "Webhook enviado a %endpoint% (%event%)",
+    "webhook-no-codes": "Selecciona al menos un registro"
 }

--- a/Plugins/Webhooks/XMLView/WebhookRule.xml
+++ b/Plugins/Webhooks/XMLView/WebhookRule.xml
@@ -21,10 +21,13 @@
         <column name="on_update" order="60">
             <widget type="checkbox" fieldname="on_update" />
         </column>
-        <column name="condition_text" order="70">
+        <column name="on_action" order="70">
+            <widget type="checkbox" fieldname="on_action" />
+        </column>
+        <column name="condition_text" order="80">
             <widget type="textarea" fieldname="condition_text" rows="2" placeholder="serie = X; estado = 3" />
         </column>
-        <column name="previous_condition_text" order="80">
+        <column name="previous_condition_text" order="90">
             <widget type="textarea" fieldname="previous_condition_text" rows="2" placeholder="estado = 3" />
         </column>
     </columns>

--- a/Plugins/Webhooks/XMLView/WebhookRule.xml
+++ b/Plugins/Webhooks/XMLView/WebhookRule.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<view>
+    <columns>
+        <column name="description" order="10">
+            <widget type="text" fieldname="description" placeholder="Descripción" />
+        </column>
+        <column name="model" order="20">
+            <widget type="select" fieldname="model" required="true">
+                <values />
+            </widget>
+        </column>
+        <column name="endpoint" order="30">
+            <widget type="text" fieldname="endpoint" placeholder="https://..." />
+        </column>
+        <column name="active" order="40">
+            <widget type="checkbox" fieldname="active" />
+        </column>
+        <column name="on_insert" order="50">
+            <widget type="checkbox" fieldname="on_insert" />
+        </column>
+        <column name="on_update" order="60">
+            <widget type="checkbox" fieldname="on_update" />
+        </column>
+        <column name="condition_text" order="70">
+            <widget type="textarea" fieldname="condition_text" rows="2" placeholder="serie = X; estado = 3" />
+        </column>
+        <column name="previous_condition_text" order="80">
+            <widget type="textarea" fieldname="previous_condition_text" rows="2" placeholder="estado = 3" />
+        </column>
+    </columns>
+</view>

--- a/Plugins/Webhooks/facturascripts.ini
+++ b/Plugins/Webhooks/facturascripts.ini
@@ -1,4 +1,4 @@
 name = 'Webhooks'
 description = 'Dispara webhooks cuando se guardan modelos.'
-version = 1.1
+version = 1.2
 min_version = 2024

--- a/Plugins/Webhooks/facturascripts.ini
+++ b/Plugins/Webhooks/facturascripts.ini
@@ -1,0 +1,4 @@
+name = 'Webhooks'
+description = 'Dispara webhooks cuando se guardan modelos.'
+version = 1.1
+min_version = 2024


### PR DESCRIPTION
## Summary
- add support for evaluating previous-value conditions on update events and persist the new configuration field
- include previous record data and current session user in webhook payloads alongside document header/lines
- document the new payload contents and bump the plugin version

## Testing
- `find Plugins/Webhooks -name '*.php' -print0 | xargs -0 -n1 php -l`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68e820ccf3388328af6e49019fdb212f)