### PR TITLE
Add KPI Dashboards plugin scaffold

### DIFF
--- a/Plugins/KpiDashboards/Controller/EditKpiDashboard.php
+++ b/Plugins/KpiDashboards/Controller/EditKpiDashboard.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Dinamic\Controller;
+
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Core\Lib\ExtendedController\EditController;
+
+/**
+ * Controller to edit KPI dashboards.
+ */
+class EditKpiDashboard extends EditController
+{
+    public function getModelClassName(): string
+    {
+        return 'KpiDashboard';
+    }
+
+    public function getPageData(): array
+    {
+        $data = parent::getPageData();
+        $data['menu'] = 'reports';
+        $data['title'] = 'kpi-dashboard';
+        $data['icon'] = 'fa-solid fa-chart-pie';
+        $data['showonmenu'] = false;
+        return $data;
+    }
+
+    protected function createViews()
+    {
+        parent::createViews();
+        $this->setTabsPosition('top');
+
+        $this->addEditListView('EditKpiWidget', 'KpiWidget', 'kpi-widgets', 'fa-solid fa-chart-line')
+            ->setInLine(true)
+            ->disableColumn('dashboard', true);
+
+        $this->addEditListView('EditKpiDashboardShare', 'KpiDashboardShare', 'kpi-sharing', 'fa-solid fa-share-nodes')
+            ->setInLine(true)
+            ->disableColumn('dashboard', true);
+    }
+
+    protected function loadData($viewName, $view)
+    {
+        $mainViewName = $this->getMainViewName();
+
+        switch ($viewName) {
+            case 'EditKpiWidget':
+                $dashboardId = $this->getViewModelValue($mainViewName, 'id');
+                if (empty($dashboardId)) {
+                    $view->setSettings('active', false);
+                    break;
+                }
+                $view->loadData('', [new DataBaseWhere('iddashboard', $dashboardId)]);
+                break;
+
+            case 'EditKpiDashboardShare':
+                $dashboardId = $this->getViewModelValue($mainViewName, 'id');
+                if (empty($dashboardId)) {
+                    $view->setSettings('active', false);
+                    break;
+                }
+                $view->loadData('', [new DataBaseWhere('iddashboard', $dashboardId)]);
+                break;
+
+            default:
+                parent::loadData($viewName, $view);
+                break;
+        }
+    }
+
+    protected function insertAction(): bool
+    {
+        $mainViewName = $this->getMainViewName();
+        if (empty($this->views[$mainViewName]->model->owner)) {
+            $this->views[$mainViewName]->model->owner = $this->user->nick;
+        }
+
+        return parent::insertAction();
+    }
+}

--- a/Plugins/KpiDashboards/Controller/ListKpiDashboard.php
+++ b/Plugins/KpiDashboards/Controller/ListKpiDashboard.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Dinamic\Controller;
+
+use FacturaScripts\Core\Lib\ExtendedController\ListController;
+
+/**
+ * Controller to list KPI dashboards.
+ */
+class ListKpiDashboard extends ListController
+{
+    public function getPageData(): array
+    {
+        $data = parent::getPageData();
+        $data['menu'] = 'reports';
+        $data['title'] = 'kpi-dashboards';
+        $data['icon'] = 'fa-solid fa-chart-pie';
+        return $data;
+    }
+
+    protected function createViews()
+    {
+        $this->addView('ListKpiDashboard', 'KpiDashboard', 'kpi-dashboards', 'fa-solid fa-chart-pie')
+            ->addSearchFields(['name', 'description', 'owner'])
+            ->addOrderBy(['name'], 'name', 1)
+            ->addOrderBy(['owner'], 'owner')
+            ->addOrderBy(['enabled'], 'enabled');
+    }
+}

--- a/Plugins/KpiDashboards/Model/KpiDashboard.php
+++ b/Plugins/KpiDashboards/Model/KpiDashboard.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Dinamic\Model;
+
+use FacturaScripts\Core\Model\Base\ModelClass;
+use FacturaScripts\Core\Tools;
+
+/**
+ * Defines a KPI dashboard.
+ */
+class KpiDashboard extends ModelClass
+{
+    use Base\ModelTrait;
+
+    /** @var string */
+    public $description;
+
+    /** @var bool */
+    public $enabled;
+
+    /** @var int */
+    public $id;
+
+    /** @var array */
+    public $layout;
+
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $owner;
+
+    /** @var string */
+    public $theme;
+
+    public function clear()
+    {
+        parent::clear();
+        $this->enabled = true;
+        $this->layout = [];
+    }
+
+    public function loadFromData(array $data = [], array $exclude = [])
+    {
+        array_push($exclude, 'layout');
+        parent::loadFromData($data, $exclude);
+
+        $decodedLayout = isset($data['layout']) ? json_decode($data['layout'], true) : null;
+        $this->layout = is_array($decodedLayout) ? $decodedLayout : [];
+    }
+
+    public static function primaryColumn(): string
+    {
+        return 'id';
+    }
+
+    public static function tableName(): string
+    {
+        return 'kpi_dashboards';
+    }
+
+    public function test(): bool
+    {
+        $this->name = Tools::noHtml($this->name);
+        $this->description = Tools::noHtml($this->description);
+        $this->theme = Tools::noHtml($this->theme);
+        $this->owner = Tools::noHtml($this->owner);
+
+        if (empty($this->name)) {
+            Tools::log()->warning('name-error');
+            return false;
+        }
+
+        return parent::test();
+    }
+
+    protected function saveInsert(array $values = []): bool
+    {
+        return parent::saveInsert($this->getEncodedValues());
+    }
+
+    protected function saveUpdate(array $values = []): bool
+    {
+        return parent::saveUpdate($this->getEncodedValues());
+    }
+
+    private function getEncodedValues(): array
+    {
+        if (is_string($this->layout)) {
+            return ['layout' => $this->layout];
+        }
+
+        return [
+            'layout' => json_encode($this->layout ?? [])
+        ];
+    }
+}

--- a/Plugins/KpiDashboards/Model/KpiDashboardShare.php
+++ b/Plugins/KpiDashboards/Model/KpiDashboardShare.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Dinamic\Model;
+
+use FacturaScripts\Core\Model\Base\ModelClass;
+use FacturaScripts\Core\Tools;
+
+/**
+ * Defines sharing rules for KPI dashboards.
+ */
+class KpiDashboardShare extends ModelClass
+{
+    use Base\ModelTrait;
+
+    /** @var bool */
+    public $canedit;
+
+    /** @var string */
+    public $codrole;
+
+    /** @var int */
+    public $iddashboard;
+
+    /** @var int */
+    public $id;
+
+    /** @var string */
+    public $nick;
+
+    /** @var string */
+    public $sharetype;
+
+    public function clear()
+    {
+        parent::clear();
+        $this->sharetype = 'user';
+        $this->canedit = false;
+    }
+
+    public static function primaryColumn(): string
+    {
+        return 'id';
+    }
+
+    public static function tableName(): string
+    {
+        return 'kpi_dashboard_shares';
+    }
+
+    public function test(): bool
+    {
+        $this->sharetype = Tools::noHtml($this->sharetype);
+        $this->nick = Tools::noHtml($this->nick);
+        $this->codrole = Tools::noHtml($this->codrole);
+
+        if (!in_array($this->sharetype, ['user', 'role'], true)) {
+            Tools::log()->warning('kpi-share-type-invalid');
+            return false;
+        }
+
+        if ($this->sharetype === 'user' && empty($this->nick)) {
+            Tools::log()->warning('kpi-share-user-missing');
+            return false;
+        }
+
+        if ($this->sharetype === 'role' && empty($this->codrole)) {
+            Tools::log()->warning('kpi-share-role-missing');
+            return false;
+        }
+
+        return parent::test();
+    }
+}

--- a/Plugins/KpiDashboards/Model/KpiWidget.php
+++ b/Plugins/KpiDashboards/Model/KpiWidget.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Dinamic\Model;
+
+use FacturaScripts\Core\Model\Base\ModelClass;
+use FacturaScripts\Core\Tools;
+
+/**
+ * Defines a KPI widget inside a dashboard.
+ */
+class KpiWidget extends ModelClass
+{
+    use Base\ModelTrait;
+
+    /** @var array */
+    public $config;
+
+    /** @var int */
+    public $iddashboard;
+
+    /** @var int */
+    public $id;
+
+    /** @var int */
+    public $position;
+
+    /** @var string */
+    public $title;
+
+    /** @var string */
+    public $type;
+
+    public function clear()
+    {
+        parent::clear();
+        $this->config = [];
+        $this->position = 0;
+        $this->type = 'numeric';
+    }
+
+    public function loadFromData(array $data = [], array $exclude = [])
+    {
+        array_push($exclude, 'config');
+        parent::loadFromData($data, $exclude);
+
+        $decodedConfig = isset($data['config']) ? json_decode($data['config'], true) : null;
+        $this->config = is_array($decodedConfig) ? $decodedConfig : [];
+    }
+
+    public static function primaryColumn(): string
+    {
+        return 'id';
+    }
+
+    public static function tableName(): string
+    {
+        return 'kpi_widgets';
+    }
+
+    public function test(): bool
+    {
+        $this->title = Tools::noHtml($this->title);
+        $this->type = Tools::noHtml($this->type);
+
+        if (!in_array($this->type, static::allowedTypes(), true)) {
+            Tools::log()->warning('kpi-widget-type-invalid');
+            return false;
+        }
+
+        return parent::test();
+    }
+
+    public static function allowedTypes(): array
+    {
+        return [
+            'chart',
+            'table',
+            'donut',
+            'funnel',
+            'numeric',
+            'percentage'
+        ];
+    }
+
+    protected function saveInsert(array $values = []): bool
+    {
+        return parent::saveInsert($this->getEncodedValues());
+    }
+
+    protected function saveUpdate(array $values = []): bool
+    {
+        return parent::saveUpdate($this->getEncodedValues());
+    }
+
+    private function getEncodedValues(): array
+    {
+        if (is_string($this->config)) {
+            return ['config' => $this->config];
+        }
+
+        return [
+            'config' => json_encode($this->config ?? [])
+        ];
+    }
+}

--- a/Plugins/KpiDashboards/Table/kpi_dashboard_shares.xml
+++ b/Plugins/KpiDashboards/Table/kpi_dashboard_shares.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Table definition for KPI dashboard sharing rules.
+-->
+<table>
+    <column>
+        <name>id</name>
+        <type>serial</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>iddashboard</name>
+        <type>integer</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>sharetype</name>
+        <type>character varying(20)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>nick</name>
+        <type>character varying(50)</type>
+    </column>
+    <column>
+        <name>codrole</name>
+        <type>character varying(20)</type>
+    </column>
+    <column>
+        <name>canedit</name>
+        <type>boolean</type>
+        <default>false</default>
+    </column>
+    <constraint>
+        <name>kpi_dashboard_shares_pkey</name>
+        <type>PRIMARY KEY (id)</type>
+    </constraint>
+    <constraint>
+        <name>kpi_dashboard_shares_dashboard_fk</name>
+        <type>FOREIGN KEY (iddashboard) REFERENCES kpi_dashboards (id) ON DELETE CASCADE ON UPDATE CASCADE</type>
+    </constraint>
+    <constraint>
+        <name>kpi_dashboard_shares_nick_fk</name>
+        <type>FOREIGN KEY (nick) REFERENCES users (nick) ON DELETE SET NULL ON UPDATE CASCADE</type>
+    </constraint>
+    <constraint>
+        <name>kpi_dashboard_shares_role_fk</name>
+        <type>FOREIGN KEY (codrole) REFERENCES roles (codrole) ON DELETE SET NULL ON UPDATE CASCADE</type>
+    </constraint>
+</table>

--- a/Plugins/KpiDashboards/Table/kpi_dashboards.xml
+++ b/Plugins/KpiDashboards/Table/kpi_dashboards.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Table definition for KPI dashboards.
+-->
+<table>
+    <column>
+        <name>id</name>
+        <type>serial</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>name</name>
+        <type>character varying(100)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>description</name>
+        <type>character varying(300)</type>
+    </column>
+    <column>
+        <name>layout</name>
+        <type>text</type>
+    </column>
+    <column>
+        <name>theme</name>
+        <type>character varying(50)</type>
+    </column>
+    <column>
+        <name>owner</name>
+        <type>character varying(50)</type>
+    </column>
+    <column>
+        <name>enabled</name>
+        <type>boolean</type>
+        <default>true</default>
+    </column>
+    <constraint>
+        <name>kpi_dashboards_pkey</name>
+        <type>PRIMARY KEY (id)</type>
+    </constraint>
+    <constraint>
+        <name>kpi_dashboards_owner_fk</name>
+        <type>FOREIGN KEY (owner) REFERENCES users (nick) ON DELETE SET NULL ON UPDATE CASCADE</type>
+    </constraint>
+</table>

--- a/Plugins/KpiDashboards/Table/kpi_widgets.xml
+++ b/Plugins/KpiDashboards/Table/kpi_widgets.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Table definition for KPI widgets.
+-->
+<table>
+    <column>
+        <name>id</name>
+        <type>serial</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>iddashboard</name>
+        <type>integer</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>title</name>
+        <type>character varying(150)</type>
+    </column>
+    <column>
+        <name>type</name>
+        <type>character varying(30)</type>
+        <null>NO</null>
+    </column>
+    <column>
+        <name>position</name>
+        <type>integer</type>
+        <default>0</default>
+    </column>
+    <column>
+        <name>config</name>
+        <type>text</type>
+    </column>
+    <constraint>
+        <name>kpi_widgets_pkey</name>
+        <type>PRIMARY KEY (id)</type>
+    </constraint>
+    <constraint>
+        <name>kpi_widgets_dashboard_fk</name>
+        <type>FOREIGN KEY (iddashboard) REFERENCES kpi_dashboards (id) ON DELETE CASCADE ON UPDATE CASCADE</type>
+    </constraint>
+</table>

--- a/Plugins/KpiDashboards/Translation/en_EN.json
+++ b/Plugins/KpiDashboards/Translation/en_EN.json
@@ -1,0 +1,8 @@
+{
+    "kpi-dashboards": "KPI dashboards",
+    "kpi-dashboard": "KPI dashboard",
+    "kpi-widgets": "KPI widgets",
+    "kpi-sharing": "KPI sharing",
+    "share-type": "Share type",
+    "can-edit": "Can edit"
+}

--- a/Plugins/KpiDashboards/Translation/es_ES.json
+++ b/Plugins/KpiDashboards/Translation/es_ES.json
@@ -1,0 +1,8 @@
+{
+    "kpi-dashboards": "Cuadros de mando KPI",
+    "kpi-dashboard": "Cuadro de mando KPI",
+    "kpi-widgets": "Widgets KPI",
+    "kpi-sharing": "Compartir KPIs",
+    "share-type": "Tipo de compartición",
+    "can-edit": "Puede editar"
+}

--- a/Plugins/KpiDashboards/XMLView/EditKpiDashboard.xml
+++ b/Plugins/KpiDashboards/XMLView/EditKpiDashboard.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * KPI dashboard edit view.
+-->
+<view>
+    <columns>
+        <group name="data" numcolumns="12">
+            <column name="code" description="optional" display="none" numcolumns="2" order="100">
+                <widget type="text" fieldname="id" readonly="true" />
+            </column>
+            <column name="name" numcolumns="6" order="110">
+                <widget type="text" fieldname="name" required="true" />
+            </column>
+            <column name="owner" numcolumns="3" order="120">
+                <widget type="select" fieldname="owner">
+                    <values source="users" fieldcode="nick" fieldtitle="nick" />
+                </widget>
+            </column>
+            <column name="enabled" numcolumns="3" order="130">
+                <widget type="checkbox" fieldname="enabled" />
+            </column>
+            <column name="theme" numcolumns="3" order="140">
+                <widget type="select" fieldname="theme">
+                    <values>
+                        <value key="default">default</value>
+                        <value key="light">light</value>
+                        <value key="dark">dark</value>
+                    </values>
+                </widget>
+            </column>
+            <column name="description" numcolumns="12" order="150">
+                <widget type="textarea" fieldname="description" />
+            </column>
+            <column name="layout" numcolumns="12" order="160">
+                <widget type="textarea" fieldname="layout" />
+            </column>
+        </group>
+    </columns>
+</view>

--- a/Plugins/KpiDashboards/XMLView/EditKpiDashboardShare.xml
+++ b/Plugins/KpiDashboards/XMLView/EditKpiDashboardShare.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * KPI dashboard sharing edit view.
+-->
+<view>
+    <columns>
+        <group name="data" numcolumns="12">
+            <column name="dashboard" description="optional" display="none" numcolumns="2" order="100">
+                <widget type="number" fieldname="iddashboard" readonly="true" />
+            </column>
+            <column name="share-type" numcolumns="3" order="110">
+                <widget type="select" fieldname="sharetype" required="true">
+                    <values>
+                        <value key="user">user</value>
+                        <value key="role">role</value>
+                    </values>
+                </widget>
+            </column>
+            <column name="user" numcolumns="4" order="120">
+                <widget type="select" fieldname="nick">
+                    <values source="users" fieldcode="nick" fieldtitle="nick" />
+                </widget>
+            </column>
+            <column name="role" numcolumns="3" order="130">
+                <widget type="select" fieldname="codrole">
+                    <values source="roles" fieldcode="codrole" fieldtitle="descripcion" />
+                </widget>
+            </column>
+            <column name="can-edit" numcolumns="2" order="140">
+                <widget type="checkbox" fieldname="canedit" />
+            </column>
+        </group>
+    </columns>
+</view>

--- a/Plugins/KpiDashboards/XMLView/EditKpiWidget.xml
+++ b/Plugins/KpiDashboards/XMLView/EditKpiWidget.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * KPI widget edit view.
+-->
+<view>
+    <columns>
+        <group name="data" numcolumns="12">
+            <column name="dashboard" description="optional" display="none" numcolumns="2" order="100">
+                <widget type="number" fieldname="iddashboard" readonly="true" />
+            </column>
+            <column name="title" numcolumns="5" order="110">
+                <widget type="text" fieldname="title" required="true" />
+            </column>
+            <column name="type" numcolumns="3" order="120">
+                <widget type="select" fieldname="type" required="true">
+                    <values>
+                        <value key="chart">chart</value>
+                        <value key="table">table</value>
+                        <value key="donut">donut</value>
+                        <value key="funnel">funnel</value>
+                        <value key="numeric">numeric</value>
+                        <value key="percentage">percentage</value>
+                    </values>
+                </widget>
+            </column>
+            <column name="position" numcolumns="2" order="130">
+                <widget type="number" fieldname="position" />
+            </column>
+            <column name="config" numcolumns="12" order="140">
+                <widget type="textarea" fieldname="config" />
+            </column>
+        </group>
+    </columns>
+</view>

--- a/Plugins/KpiDashboards/XMLView/ListKpiDashboard.xml
+++ b/Plugins/KpiDashboards/XMLView/ListKpiDashboard.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * KPI dashboards list view.
+-->
+<view>
+    <columns>
+        <column name="code" order="100">
+            <widget type="text" fieldname="id" onclick="EditKpiDashboard" />
+        </column>
+        <column name="name" order="110">
+            <widget type="text" fieldname="name" />
+        </column>
+        <column name="owner" order="120">
+            <widget type="select" fieldname="owner">
+                <values source="users" fieldcode="nick" fieldtitle="nick" />
+            </widget>
+        </column>
+        <column name="enabled" display="center" order="130">
+            <widget type="checkbox" fieldname="enabled" />
+        </column>
+        <column name="description" order="140">
+            <widget type="text" fieldname="description" />
+        </column>
+    </columns>
+</view>

--- a/Plugins/KpiDashboards/facturascripts.ini
+++ b/Plugins/KpiDashboards/facturascripts.ini
@@ -1,0 +1,4 @@
+name = 'KpiDashboards'
+description = 'Cuadros de mando con KPIs personalizables y compartibles.'
+version = 1
+min_version = 2023


### PR DESCRIPTION
### Motivation
- Provide a new plugin to create customizable KPI dashboards with widgets (charts, tables, donuts, funnels, numeric, percentage) and sharing rules.  
- Allow users to create multiple dashboards, configure widget layouts and share dashboards with users or roles.  
- Integrate dashboard management into the existing FacturaScripts UI using controllers and XML view definitions.  

### Description
- Add plugin scaffold `Plugins/KpiDashboards` with metadata in `facturascripts.ini` and translations `Translation/en_EN.json` and `Translation/es_ES.json`.  
- Add models `KpiDashboard`, `KpiWidget` and `KpiDashboardShare` under `Model/` plus defensive JSON handling in `loadFromData` and `getEncodedValues` to accept string or array payloads.  
- Add controllers `ListKpiDashboard` and `EditKpiDashboard` and XML views under `XMLView/` to list and edit dashboards, widgets and sharing rules.  
- Add table definitions under `Table/` for `kpi_dashboards`, `kpi_widgets` and `kpi_dashboard_shares` to create the required DB schema.  

### Testing
- No automated tests were executed as part of this change (no PHPUnit/CI run was requested).  
- No new unit tests were added in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962a9e7d998832881068029fbcda447)