### PR TITLE
Add supplier reference (`refproveedor`) to purchase lines and plugin to autofill from `productosprov`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 /doc/
 /MyFiles/
 /node_modules/
-/Plugins/
+/Plugins/*
+!/Plugins/RefProveedorLineas/
+!/Plugins/RefProveedorLineas/**
 /vendor/
 .DS_Store
 .htaccess

--- a/Plugins/RefProveedorLineas/Extension/Model/Base/PurchaseDocument.php
+++ b/Plugins/RefProveedorLineas/Extension/Model/Base/PurchaseDocument.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Plugins\RefProveedorLineas\Extension\Model\Base;
+
+use FacturaScripts\Core\Base\DataBase\DataBaseWhere;
+use FacturaScripts\Dinamic\Model\ProductoProveedor;
+use FacturaScripts\Dinamic\Model\Variante;
+
+class PurchaseDocument
+{
+    public function getNewProductLine(): callable
+    {
+        return function ($newLine, Variante $variant, $product): void {
+            if (empty($newLine->referencia) || empty($this->codproveedor)) {
+                return;
+            }
+
+            $refProveedor = $this->findSupplierReference($newLine->referencia);
+            if ($refProveedor !== null) {
+                $newLine->refproveedor = $refProveedor;
+            }
+        };
+    }
+
+    private function findSupplierReference(string $referencia): ?string
+    {
+        $supplierProd = new ProductoProveedor();
+        $where = [
+            new DataBaseWhere('codproveedor', $this->codproveedor),
+            new DataBaseWhere('referencia', $referencia),
+        ];
+        $orderBy = ['coddivisa' => 'DESC'];
+        foreach ($supplierProd->all($where, $orderBy) as $prod) {
+            if ($prod->coddivisa === $this->coddivisa || $prod->coddivisa === null) {
+                return $prod->refproveedor;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Plugins/RefProveedorLineas/Init.php
+++ b/Plugins/RefProveedorLineas/Init.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ * Copyright (C) 2024
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Plugins\RefProveedorLineas;
+
+use FacturaScripts\Core\Base\DataBase;
+use FacturaScripts\Core\Lib\AjaxForms\PurchasesLineHTML;
+use FacturaScripts\Core\Template\InitClass;
+use FacturaScripts\Plugins\RefProveedorLineas\Extension\Model\Base\PurchaseDocument;
+use FacturaScripts\Plugins\RefProveedorLineas\Lib\RefProveedorLineMod;
+
+class Init extends InitClass
+{
+    public function init(): void
+    {
+        $this->loadExtension(new PurchaseDocument());
+        PurchasesLineHTML::addMod(new RefProveedorLineMod());
+    }
+
+    public function uninstall(): void
+    {
+    }
+
+    public function update(): void
+    {
+        $dataBase = new DataBase();
+        if (false === $dataBase->connect()) {
+            return;
+        }
+
+        $tables = [
+            'lineasalbaranesprov',
+            'lineasfacturasprov',
+            'lineaspedidosprov',
+            'lineaspresupuestosprov',
+        ];
+
+        foreach ($tables as $tableName) {
+            $this->ensureRefProveedorColumn($dataBase, $tableName);
+        }
+    }
+
+    private function ensureRefProveedorColumn(DataBase $dataBase, string $tableName): void
+    {
+        if (false === $dataBase->tableExists($tableName)) {
+            return;
+        }
+
+        $columns = $dataBase->getColumns($tableName);
+        if (isset($columns['refproveedor'])) {
+            return;
+        }
+
+        $sql = sprintf('ALTER TABLE %s ADD COLUMN refproveedor VARCHAR(30);', $tableName);
+        $dataBase->exec($sql);
+    }
+}

--- a/Plugins/RefProveedorLineas/Lib/RefProveedorLineMod.php
+++ b/Plugins/RefProveedorLineas/Lib/RefProveedorLineMod.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Plugins\RefProveedorLineas\Lib;
+
+use FacturaScripts\Core\Contract\PurchasesLineModInterface;
+use FacturaScripts\Core\Model\Base\PurchaseDocument;
+use FacturaScripts\Core\Model\Base\PurchaseDocumentLine;
+use FacturaScripts\Core\Tools;
+
+class RefProveedorLineMod implements PurchasesLineModInterface
+{
+    public function apply(PurchaseDocument &$model, array &$lines, array $formData): void
+    {
+    }
+
+    public function applyToLine(array $formData, PurchaseDocumentLine &$line, string $id): void
+    {
+        $value = $formData['refproveedor_' . $id] ?? null;
+        if ($value !== null) {
+            $line->refproveedor = Tools::noHtml($value);
+        }
+    }
+
+    public function assets(): void
+    {
+    }
+
+    public function getFastLine(PurchaseDocument $model, array $formData): ?PurchaseDocumentLine
+    {
+        return null;
+    }
+
+    public function map(array $lines, PurchaseDocument $model): array
+    {
+        $map = [];
+        foreach ($lines as $line) {
+            $idlinea = $line->idlinea;
+            if ($idlinea === null) {
+                continue;
+            }
+
+            $map['refproveedor_' . $idlinea] = $line->refproveedor;
+        }
+
+        return $map;
+    }
+
+    public function newFields(): array
+    {
+        return ['refproveedor'];
+    }
+
+    public function newModalFields(): array
+    {
+        return [];
+    }
+
+    public function newTitles(): array
+    {
+        return ['refproveedor'];
+    }
+
+    public function renderField(string $idlinea, PurchaseDocumentLine $line, PurchaseDocument $model, string $field): ?string
+    {
+        if ($field !== 'refproveedor') {
+            return null;
+        }
+
+        $value = Tools::fixHtml($line->refproveedor ?? '');
+        $label = Tools::lang()->trans('supplier-reference');
+        $attributes = $model->editable ?
+            'name="refproveedor_' . $idlinea . '" maxlength="30"' :
+            'disabled=""';
+
+        return '<div class="col-sm-2 col-lg-2 order-4">'
+            . '<div class="d-lg-none mt-2 small">' . $label . '</div>'
+            . '<input type="text" ' . $attributes . ' value="' . $value
+            . '" class="form-control form-control-sm border-0"/>'
+            . '</div>';
+    }
+
+    public function renderTitle(PurchaseDocument $model, string $field): ?string
+    {
+        if ($field !== 'refproveedor') {
+            return null;
+        }
+
+        return '<div class="col-lg-2">' . Tools::lang()->trans('supplier-reference') . '</div>';
+    }
+}

--- a/Plugins/RefProveedorLineas/Model/LineaAlbaranProveedor.php
+++ b/Plugins/RefProveedorLineas/Model/LineaAlbaranProveedor.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Plugins\RefProveedorLineas\Model;
+
+class LineaAlbaranProveedor extends \FacturaScripts\Core\Model\LineaAlbaranProveedor
+{
+    /** @var string|null */
+    public $refproveedor;
+}

--- a/Plugins/RefProveedorLineas/Model/LineaFacturaProveedor.php
+++ b/Plugins/RefProveedorLineas/Model/LineaFacturaProveedor.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Plugins\RefProveedorLineas\Model;
+
+class LineaFacturaProveedor extends \FacturaScripts\Core\Model\LineaFacturaProveedor
+{
+    /** @var string|null */
+    public $refproveedor;
+}

--- a/Plugins/RefProveedorLineas/Model/LineaPedidoProveedor.php
+++ b/Plugins/RefProveedorLineas/Model/LineaPedidoProveedor.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Plugins\RefProveedorLineas\Model;
+
+class LineaPedidoProveedor extends \FacturaScripts\Core\Model\LineaPedidoProveedor
+{
+    /** @var string|null */
+    public $refproveedor;
+}

--- a/Plugins/RefProveedorLineas/Model/LineaPresupuestoProveedor.php
+++ b/Plugins/RefProveedorLineas/Model/LineaPresupuestoProveedor.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace FacturaScripts\Plugins\RefProveedorLineas\Model;
+
+class LineaPresupuestoProveedor extends \FacturaScripts\Core\Model\LineaPresupuestoProveedor
+{
+    /** @var string|null */
+    public $refproveedor;
+}

--- a/Plugins/RefProveedorLineas/facturascripts.ini
+++ b/Plugins/RefProveedorLineas/facturascripts.ini
@@ -1,0 +1,4 @@
+name = "RefProveedorLineas"
+description = "Añade la referencia del proveedor en las líneas de compra y la completa desde productosprov."
+version = 1
+min_version = 2024.1


### PR DESCRIPTION
### Motivation

- Añadir el campo `refproveedor` a las líneas de los documentos de compra (Pedido, Presupuesto, Albarán, Factura) para almacenar la referencia del proveedor por línea.
- Cuando se seleccione la referencia de artículo en la línea, rellenar automáticamente `refproveedor` buscando en la tabla `productosprov` según el proveedor del encabezado.
- Proveer la interfaz en el formulario de líneas de compra para ver/editar la `Ref. Proveedor` en cada línea.
- Asegurar que las tablas de líneas de compra contienen la columna `refproveedor` al activar/actualizar el plugin.

### Description

- Añadido el plugin `RefProveedorLineas` con `Init.php` que registra la extensión y el modulador de líneas; y agrega una migración que crea la columna `refproveedor` en las tablas de líneas si falta (`lineasalbaranesprov`, `lineasfacturasprov`, `lineaspedidosprov`, `lineaspresupuestosprov`).
- Implementada la extensión `Extension\Model\Base\PurchaseDocument` que aporta `getNewProductLine()` y rellena `refproveedor` consultando `ProductoProveedor` (tabla `productosprov`) filtrando por `codproveedor` y `referencia`.
- Añadido `Lib\RefProveedorLineMod` que implementa `PurchasesLineModInterface` para declarar el nuevo campo (`newFields`, `newTitles`), mapear su valor (`map`), aplicarlo en `applyToLine` y renderizar la columna/entrada en la UI de líneas de compra.
- Creado wrappers de modelo en `Plugins/RefProveedorLineas/Model/Linea*.php` para exponer la propiedad pública `refproveedor` en las clases de línea de compra; y añadido `facturascripts.ini` y ajustes en `.gitignore` para incluir el plugin en el repo.

### Testing

- No se ejecutaron pruebas automatizadas (`phpunit` u otras) durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696648055dc08328991afc1b5803758a)