### PR TITLE
Agregar plugin IframeEmbed para permitir embedding en iframe desde orígenes configurados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /MyFiles/
 /node_modules/
 /Plugins/
+!/Plugins/
+/Plugins/*
+!/Plugins/IframeEmbed/
+!/Plugins/IframeEmbed/**
 /vendor/
 .DS_Store
 .htaccess

--- a/Plugins/IframeEmbed/Init.php
+++ b/Plugins/IframeEmbed/Init.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of FacturaScripts
+ *
+ * Plugin to allow embedding FacturaScripts in an iframe from configured domains.
+ */
+
+namespace FacturaScripts\Plugins\IframeEmbed;
+
+use FacturaScripts\Core\Template\InitClass;
+use FacturaScripts\Core\Tools;
+
+class Init extends InitClass
+{
+    public function init(): void
+    {
+        $origins = $this->getAllowedOrigins();
+        if (empty($origins)) {
+            return;
+        }
+
+        header_register_callback(static function () use ($origins) {
+            header_remove('X-Frame-Options');
+
+            $frameAncestors = implode(' ', array_merge(["'self'"], $origins));
+            header('Content-Security-Policy: frame-ancestors ' . $frameAncestors, true);
+        });
+    }
+
+    public function uninstall(): void
+    {
+    }
+
+    public function update(): void
+    {
+    }
+
+    private function getAllowedOrigins(): array
+    {
+        $configured = trim((string)Tools::config('iframe_allowed_origins', ''));
+        if ($configured === '') {
+            return [];
+        }
+
+        $origins = preg_split('/[\s,;]+/', $configured);
+        $validOrigins = [];
+
+        foreach ($origins as $origin) {
+            $origin = trim($origin);
+            if ($origin === '' || !$this->isValidOrigin($origin)) {
+                continue;
+            }
+
+            $validOrigins[] = $origin;
+        }
+
+        return array_values(array_unique($validOrigins));
+    }
+
+    private function isValidOrigin(string $origin): bool
+    {
+        return (bool)preg_match('/^https?:\/\/[a-z0-9.-]+(?::\d+)?$/i', $origin);
+    }
+}

--- a/Plugins/IframeEmbed/README.md
+++ b/Plugins/IframeEmbed/README.md
@@ -1,0 +1,20 @@
+# IframeEmbed
+
+Este plugin permite cargar FacturaScripts dentro de un `iframe` desde dominios concretos.
+
+## Configuración
+
+Añade en tu `config.php` la constante `FS_IFRAME_ALLOWED_ORIGINS` con una lista de orígenes separados por comas, espacios o `;`.
+
+Ejemplo:
+
+```php
+define('FS_IFRAME_ALLOWED_ORIGINS', 'https://mi-dominio.com, https://intranet.miempresa.com:8443');
+```
+
+## Qué hace
+
+- Elimina la cabecera `X-Frame-Options`.
+- Añade `Content-Security-Policy` con `frame-ancestors 'self' ...` usando solo los orígenes válidos configurados.
+
+Si no se configura `FS_IFRAME_ALLOWED_ORIGINS`, el plugin no altera cabeceras.

--- a/Plugins/IframeEmbed/facturascripts.ini
+++ b/Plugins/IframeEmbed/facturascripts.ini
@@ -1,0 +1,4 @@
+name = 'IframeEmbed'
+description = 'Permite embeber FacturaScripts en iframe para los dominios configurados en FS_IFRAME_ALLOWED_ORIGINS.'
+version = 1
+min_version = 2024.9


### PR DESCRIPTION
### Motivation
- Permitir que FacturaScripts pueda cargarse dentro de un `iframe` en dominios concretos ya que actualmente las cabeceras de seguridad lo impiden.
- Proporcionar una forma configurable y segura (lista de orígenes) para habilitar embedding en entornos controlados.
- Versionar sólo este plugin dentro de `/Plugins` manteniendo el resto del directorio ignorado por Git.

### Description
- Añade el plugin `Plugins/IframeEmbed/Init.php` que extiende `InitClass`, registra un callback de cabeceras que elimina `X-Frame-Options` y añade `Content-Security-Policy: frame-ancestors 'self' ...` con los orígenes permitidos validados y deduplicados desde la configuración `FS_IFRAME_ALLOWED_ORIGINS` (acceso vía `Tools::config`).
- Incluye el manifiesto `Plugins/IframeEmbed/facturascripts.ini` y `Plugins/IframeEmbed/README.md` con instrucciones y ejemplo de uso (`define('FS_IFRAME_ALLOWED_ORIGINS', 'https://mi-dominio.com, https://intranet.miempresa.com:8443');`).
- Actualiza `.gitignore` para permitir versionar `Plugins/IframeEmbed/` sin exponer el resto de la carpeta `/Plugins`.

### Testing
- Ejecutado `php -l Plugins/IframeEmbed/Init.php` y no se detectaron errores de sintaxis (éxito).
- Ejecutado `php -l index.php` y no se detectaron errores de sintaxis (éxito).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7e00969108328bc8250bcb935630e)